### PR TITLE
Simplify and optimize shadowed patch drawing

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -107,7 +107,7 @@ static SDL_Texture *yelpane = NULL;
 static SDL_Texture *grnpane = NULL;
 static int pane_alpha;
 static unsigned int rmask, gmask, bmask, amask; // [crispy] moved up here
-static const uint8_t blend_alpha = 0x98;// [JN] 152, slightly brighten than 0xa8 (168);
+static const uint8_t blend_alpha = 0xa8;
 extern pixel_t* colormaps; // [crispy] evil hack to get FPS dots working as in Vanilla
 #else
 static SDL_Color palette[256];

--- a/src/v_trans.c
+++ b/src/v_trans.c
@@ -27,7 +27,6 @@
 // -----------------------------------------------------------------------------
 
 static byte cr_dark[256];
-static byte cr_monochrome[256];
 
 static byte cr_menu_bright5[256];
 static byte cr_menu_bright4[256];
@@ -129,7 +128,6 @@ static const byte cr_red2green[256] =
 byte *cr[] =
 {
     (byte *) &cr_dark,
-    (byte *) &cr_monochrome,
     
     (byte *) &cr_menu_bright5,
     (byte *) &cr_menu_bright4,
@@ -409,10 +407,6 @@ byte V_Colorize (byte *playpal, int cr, byte source, boolean keepgray109)
     if (cr == CR_DARK)
     {
         hsv.z *= 0.666;
-    }
-    if (cr == CR_MONOCHROME)
-    {
-        hsv.z = 0;
     }
     // [JN] Menu glowing effects.
     else if (cr == CR_MENU_BRIGHT5)

--- a/src/v_trans.h
+++ b/src/v_trans.h
@@ -39,7 +39,6 @@
 enum
 {
     CR_DARK,
-    CR_MONOCHROME,
 
     CR_MENU_BRIGHT5,
     CR_MENU_BRIGHT4,

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -155,12 +155,12 @@ static const inline pixel_t drawpatchpx11 (const pixel_t dest, const pixel_t sou
 #else
 {return I_BlendOver(dest, colormaps[dp_translation[source]]);}
 #endif
-// [JN] shadow of the patch
+// [JN] The shadow of the patch.
 static const inline pixel_t drawshadow (const pixel_t dest, const pixel_t source)
 #ifndef CRISPY_TRUECOLOR
 {return tintmap[(dest<<8)+dp_translation[source]];}
 #else
-{return I_BlendDark(dest, 0x80);} // 128 (50%) of 256 full translucency
+{return I_BlendDark(dest, 0x80);} // [JN] 128 (50%) of 256 full translucency.
 #endif
 
 // [crispy] array of function pointers holding the different rendering functions
@@ -262,7 +262,8 @@ void V_DrawPatch(int x, int y, patch_t *patch)
 // -----------------------------------------------------------------------------
 // V_DrawShadowedPatch
 // [JN] Masks a column based masked pic to the screen.
-// Used by Doom with tintmap map.
+//  dest  - main patch, drawed second on top of shadow.
+//  dest2 - shadow, drawed first below main patch.
 // -----------------------------------------------------------------------------
 
 void V_DrawShadowedPatch(int x, int y, patch_t *patch)
@@ -275,6 +276,8 @@ void V_DrawShadowedPatch(int x, int y, patch_t *patch)
     byte *source;
     int w;
 
+    // [JN] Simplify math for shadow placement.
+    const int shadow_shift = (SCREENWIDTH << vid_hires) + (1 << vid_hires);
     // [JN] Patch itself: opaque, can be colored.
     drawpatchpx_t *const drawpatchpx = drawpatchpx_a[!dp_translucent][!dp_translation];
     // [JN] Shadow: 50% translucent, no coloring used at all.
@@ -294,7 +297,7 @@ void V_DrawShadowedPatch(int x, int y, patch_t *patch)
     }
 
     desttop = dest_screen + ((y * dy) >> FRACBITS) * SCREENWIDTH + ((x * dx) >> FRACBITS);
-    desttop2 = dest_screen + (((y + 1) * dy) >> FRACBITS) * SCREENWIDTH + (((x + 1) * dx) >> FRACBITS);
+    desttop2 = desttop + shadow_shift;
 
     w = SHORT(patch->width);
 
@@ -329,7 +332,7 @@ void V_DrawShadowedPatch(int x, int y, patch_t *patch)
             top = ((y + topdelta) * dy) >> FRACBITS;
             source = (byte *)column + 3;
             dest = desttop + ((topdelta * dy) >> FRACBITS)*SCREENWIDTH;
-            dest2 = desttop2 + ((topdelta * dy) >> FRACBITS)*SCREENWIDTH;
+            dest2 = dest + shadow_shift;
             count = (column->length * dy) >> FRACBITS;
 
             // [crispy] too low / height

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -277,7 +277,7 @@ void V_DrawShadowedPatch(int x, int y, patch_t *patch)
     int w;
 
     // [JN] Simplify math for shadow placement.
-    const int shadow_shift = (SCREENWIDTH << vid_hires) + (1 << vid_hires);
+    const int shadow_shift = (SCREENWIDTH + 1) << vid_hires;
     // [JN] Patch itself: opaque, can be colored.
     drawpatchpx_t *const drawpatchpx = drawpatchpx_a[!dp_translucent][!dp_translation];
     // [JN] Shadow: 50% translucent, no coloring used at all.


### PR DESCRIPTION
Should be slightly faster:
* Blending function switched to `I_BlendDark`, patch coloring no longer needed.
* Simplified math for shadow positioning.