### PR TITLE
Forcefully supress interpolation in video options menu

### DIFF
--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -82,6 +82,12 @@ int oldleveltime; // [crispy] check if leveltime keeps tickin'
 // [JN] used by player, render and interpolation. Always ticking.
 int realleveltime;
 
+// [JN] Forcefully supress interpolation in video options menu.
+// Needed for render will be able to do a proper update on
+// toggling resolution/widescreen modes.
+
+boolean force_capped_fps;
+
 // When set to true, a single tic is run each time TryRunTics() is called.
 // This is used for -timedemo mode.
 
@@ -123,12 +129,6 @@ static boolean local_playeringame[NET_MAXPLAYERS];
 // and saved in the game settings.
 
 static int player_class;
-
-// [JN] Forcefully supress interpolation in video options menu.
-// Needed for render will be able to do a proper update on
-// toggling resolution/widescreen modes.
-
-boolean force_capped_fps;
 
 
 // 35 fps clock adjusted by offsetms milliseconds

--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -124,6 +124,12 @@ static boolean local_playeringame[NET_MAXPLAYERS];
 
 static int player_class;
 
+// [JN] Forcefully supress interpolation in video options menu.
+// Needed for render will be able to do a proper update on
+// toggling resolution/widescreen modes.
+
+boolean force_capped_fps;
+
 
 // 35 fps clock adjusted by offsetms milliseconds
 
@@ -697,7 +703,7 @@ void TryRunTics (void)
     //      to run, return early instead of waiting around.
     // [JN] CRL - Keep uncapped framerate while paused and Spectator mode.
     extern boolean paused;
-    #define return_early (vid_uncapped_fps && counts == 0 && \
+    #define return_early (vid_uncapped_fps &&!force_capped_fps && counts == 0 && \
                          ((paused && crl_spectating) || realleveltime > oldleveltime) && \
                          screenvisible)
 

--- a/src/d_loop.h
+++ b/src/d_loop.h
@@ -80,6 +80,8 @@ extern boolean singletics;
 extern int gametic, ticdup;
 extern int oldleveltime; // [crispy] check if leveltime keeps tickin'
 
+extern boolean force_capped_fps;
+
 // Check if it is permitted to record a demo with a non-vanilla feature.
 boolean D_NonVanillaRecord(boolean conditional, char *feature);
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -4247,6 +4247,7 @@ static void M_ID_ApplyReset (int key)
 
 static void M_Choose_ID_Reset (int choice)
 {
+	force_capped_fps = true;
 	M_StartMessage(DEH_String(ID_RESET), M_ID_ApplyReset, true);
 }
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1091,6 +1091,11 @@ static void M_Draw_ID_Video (void)
 {
     static char str[32];
 
+    // [JN] Forcefully supress interpolation in video options menu.
+    // Needed for render will be able to do a proper update on
+    // toggling resolution/widescreen modes.
+    force_capped_fps = true;
+
     M_ShadeBackground();
 
     M_WriteTextCentered(18, "VIDEO OPTIONS", cr[CR_YELLOW]);
@@ -6172,14 +6177,8 @@ void M_Ticker (void)
 	skullAnimCounter = 8;
     }
 
-    // [JN] Forcefully supress interpolation in video options menu.
-    // Needed for render will be able to do a proper update on
-    // toggling resolution/widescreen modes.
-    if (vid_uncapped_fps)
-    {
-        extern boolean force_capped_fps;
-        force_capped_fps = currentMenu == &ID_Def_Video ? true : false;
-    }
+    // [JN] Disable interpolation supressing, made in M_Draw_ID_Video.
+    force_capped_fps = false;
 
     // [JN] Menu glowing animation:
     

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -6172,6 +6172,15 @@ void M_Ticker (void)
 	skullAnimCounter = 8;
     }
 
+    // [JN] Forcefully supress interpolation in video options menu.
+    // Needed for render will be able to do a proper update on
+    // toggling resolution/widescreen modes.
+    if (vid_uncapped_fps)
+    {
+        extern boolean force_capped_fps;
+        force_capped_fps = currentMenu == &ID_Def_Video ? true : false;
+    }
+
     // [JN] Menu glowing animation:
     
     // Brightening


### PR DESCRIPTION
This will fix possible silent crash on toggling resolution/widescreen in options menu while demo playing or network game, i.e. when framerate is not capped even while active menu.