### PR TITLE
Raise invulnerability priority

### DIFF
--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -637,11 +637,12 @@ static void ST_updateFaceWidget (void)
     if (priority < 10)
     {
         // dead
-        if (!plyr->health)
+        // [JN] ...or invulnerability.
+        if (!plyr->health || invul)
         {
             priority = 9;
             painoffset = 0;
-            faceindex = ST_DEADFACE;
+            faceindex = !plyr->health ? ST_DEADFACE : ST_GODFACE;
             st_facecount = 1;
         }
     }
@@ -770,19 +771,6 @@ static void ST_updateFaceWidget (void)
         else
         {
             lastattackdown = -1;
-        }
-    }
-
-    if (priority < 5)
-    {
-        // invulnerability
-        if (invul)
-        {
-            priority = 4;
-
-            painoffset = 0;
-            faceindex = ST_GODFACE;
-            st_facecount = 1;
         }
     }
 


### PR DESCRIPTION
@fabiangreffrath, @rfomin, @MrAlaux, might be interesting for you ports.

Fabian have fixed «[Status bar face hysteresis](https://doomwiki.org/wiki/Status_bar_face_hysteresis)» bug, but this goes a little bit farther: when player gets hurt, pain or ouch face have higher priority and thus, until pain/ouch tics are active, god face is unable to appear. Typical case to test: save game near invul sphere, make a face-rocket and immediately grab sphere. You will see this (i.e. evil grin in Woof, ouch/pain in Crispy Doom):

![image](https://github.com/JNechaevsky/international-doom/assets/21193394/67fd32bc-675e-49fc-b3a4-8112a382ef21)

The code below fixes it, making god face immediately active once sphere is picked up or `IDDQD` is quickly typed.