### PR TITLE
Deny all player control events while active menu in multiplayer

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -356,7 +356,7 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
     forward = side = 0;
     
     // [JN] Deny all player control events while active menu 
-    // in multuplayer to eliminate movement and camera rotation.
+    // in multiplayer to eliminate movement and camera rotation.
     if (netgame && menuactive)
 	return;
 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -355,6 +355,11 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
  
     forward = side = 0;
     
+    // [JN] Deny all player control events while active menu 
+    // in multuplayer to eliminate movement and camera rotation.
+    if (netgame && menuactive)
+	return;
+
     // use two stage accelerative turning
     // on the keyboard and joystick
     if (joyxmove < 0

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -335,6 +335,11 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
 	// needed for net games
     cmd->consistancy = consistancy[consoleplayer][maketic%BACKUPTICS]; 
  	
+	// [JN] Deny all player control events while active menu 
+	// in multiplayer to eliminate movement and camera rotation.
+ 	if (netgame && menuactive)
+ 	return;
+
  	// RestlessRodent -- If spectating then the player loses all input
  	memmove(&spect, cmd, sizeof(spect));
  	// [JN] Allow saving and pausing while spectating.
@@ -355,11 +360,6 @@ void G_BuildTiccmd (ticcmd_t* cmd, int maketic)
  
     forward = side = 0;
     
-    // [JN] Deny all player control events while active menu 
-    // in multiplayer to eliminate movement and camera rotation.
-    if (netgame && menuactive)
-	return;
-
     // use two stage accelerative turning
     // on the keyboard and joystick
     if (joyxmove < 0


### PR DESCRIPTION
This fixes player movement / camera rotation while active menu in multiplayer game or `-solo-net` mode. Seems to be safe for real multiplayer and demo recording/playback while multiplayer.

@fabiangreffrath, @rfomin, might be useful for Woof/Crispy Doom as well, but I have a hunting suspicion that it can be achieved easier or... Safer? Probably via `M_Responder` as Roman suggested, but I have no luck to properly deny mouse events there.