### PR TITLE
Allow to always draw level name

### DIFF
--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -2456,10 +2456,10 @@ static void AM_drawCrosshair (boolean force)
 }
 
 // -----------------------------------------------------------------------------
-// AM_MapNameDrawer
+// AM_LevelNameDrawer
 // -----------------------------------------------------------------------------
 
-static void AM_MapNameDrawer (void)
+void AM_LevelNameDrawer (void)
 {
     static char str[128];
     extern const char *level_name;
@@ -2469,7 +2469,7 @@ static void AM_MapNameDrawer (void)
 }
 
 // -----------------------------------------------------------------------------
-// AM_MapNameDrawer
+// AM_Drawer
 // -----------------------------------------------------------------------------
 
 void AM_Drawer (void)
@@ -2551,7 +2551,10 @@ void AM_Drawer (void)
 
     AM_drawMarks();
 	
-    AM_MapNameDrawer();
+    if (!widget_levelname)
+    {
+        AM_LevelNameDrawer();
+    }
 
     V_MarkRect(f_x, f_y, f_w, f_h);
 }

--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -2551,6 +2551,7 @@ void AM_Drawer (void)
 
     AM_drawMarks();
 	
+    // [JN] Allow to draw level name separately from automap.
     if (!widget_levelname)
     {
         AM_LevelNameDrawer();

--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -2551,7 +2551,7 @@ void AM_Drawer (void)
 
     AM_drawMarks();
 	
-    // [JN] Allow to draw level name separately from automap.
+    // [JN] Draw level name only if Level Name widget is set to "automap".
     if (!widget_levelname)
     {
         AM_LevelNameDrawer();

--- a/src/doom/am_map.h
+++ b/src/doom/am_map.h
@@ -53,6 +53,7 @@ void AM_Ticker (void);
 // Called by main loop,
 // called instead of view drawer if automap active.
 void AM_Drawer (void);
+extern void AM_LevelNameDrawer (void);
 
 // Called to force the automap to quit
 // if the level is completed while it is up.

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -325,6 +325,11 @@ static void D_Display (void)
         AM_Drawer();
     }
 
+    if (gamestate == GS_LEVEL && widget_levelname)
+    {
+        AM_LevelNameDrawer();
+    }
+
     if (testcontrols)
     {
         // Box showing current mouse speed

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -325,6 +325,7 @@ static void D_Display (void)
         AM_Drawer();
     }
 
+    // [JN] Allow to draw level name separately from automap.
     if (gamestate == GS_LEVEL && widget_levelname)
     {
         AM_LevelNameDrawer();

--- a/src/doom/id_func.c
+++ b/src/doom/id_func.c
@@ -234,6 +234,11 @@ void ID_LeftWidgets (void)
     {
         int yy = 0;
 
+        if (widget_levelname && !automapactive)
+        {
+            yy -= 9;
+        }
+
         // Render counters
         if (widget_render)
         {

--- a/src/doom/id_func.c
+++ b/src/doom/id_func.c
@@ -234,6 +234,7 @@ void ID_LeftWidgets (void)
     {
         int yy = 0;
 
+        // Shift widgets one line up if Level Name widget is set to "always".
         if (widget_levelname && !automapactive)
         {
             yy -= 9;

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -658,6 +658,7 @@ static void M_ID_Widget_Location (int choice);
 static void M_ID_Widget_KIS (int choice);
 static void M_ID_Widget_Time (int choice);
 static void M_ID_Widget_TotalTime (int choice);
+static void M_ID_Widget_LevelName (int choice);
 static void M_ID_Widget_Coords (int choice);
 static void M_ID_Widget_Render (int choice);
 static void M_ID_Widget_Health (int choice);
@@ -2873,6 +2874,7 @@ static menuitem_t ID_Menu_Widgets[]=
     { M_LFRT, "KIS STATS/FRAGS",     M_ID_Widget_KIS,        'k'},
     { M_LFRT, "LEVEL/DM TIMER",      M_ID_Widget_Time,       'l'},
     { M_LFRT, "TOTAL TIME",          M_ID_Widget_TotalTime,  't'},
+    { M_LFRT, "LEVEL NAME",          M_ID_Widget_LevelName,  'l'},
     { M_LFRT, "PLAYER COORDS",       M_ID_Widget_Coords,     'p'},
     { M_LFRT, "RENDER COUNTERS",     M_ID_Widget_Render,     'r'},
     { M_LFRT, "TARGET'S HEALTH",     M_ID_Widget_Health,     't'},
@@ -2933,59 +2935,64 @@ static void M_Draw_ID_Widgets (void)
     M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 54, str,
                  M_Item_Glow(3, widget_totaltime ? GLOW_GREEN : GLOW_DARKRED));
 
+    // Level name
+    sprintf(str, widget_levelname ? "ALWAYS" : "AUTOMAP");
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 63, str,
+                 M_Item_Glow(4, widget_levelname ? GLOW_GREEN : GLOW_DARKRED));
+
     // Player coords
     sprintf(str, widget_coords == 1 ? "ALWAYS"  :
                  widget_coords == 2 ? "AUTOMAP" : "OFF");
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 63, str,
-                 M_Item_Glow(4, widget_coords ? GLOW_GREEN : GLOW_DARKRED));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 72, str,
+                 M_Item_Glow(5, widget_coords ? GLOW_GREEN : GLOW_DARKRED));
 
     // Rendering counters
     sprintf(str, widget_render ? "ON" : "OFF");
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 72, str,
-                 M_Item_Glow(5, widget_render ? GLOW_GREEN : GLOW_DARKRED));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 81, str,
+                 M_Item_Glow(6, widget_render ? GLOW_GREEN : GLOW_DARKRED));
 
     // Target's health
     sprintf(str, widget_health == 1 ? "TOP" :
                  widget_health == 2 ? "TOP+NAME" :
                  widget_health == 3 ? "BOTTOM" :
                  widget_health == 4 ? "BOTTOM+NAME" : "OFF");
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 81, str,
-                 M_Item_Glow(6, widget_health ? GLOW_GREEN : GLOW_DARKRED));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 90, str,
+                 M_Item_Glow(7, widget_health ? GLOW_GREEN : GLOW_DARKRED));
 
-    M_WriteTextCentered(90, "AUTOMAP", cr[CR_YELLOW]);
+    M_WriteTextCentered(99, "AUTOMAP", cr[CR_YELLOW]);
 
     // Color scheme
     sprintf(str, automap_scheme == 1 ? "BOOM" :
                  automap_scheme == 2 ? "UNITY" :
                  automap_scheme == 3 ? "JAGUAR" :
                                            "ORIGINAL");
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 99, str,
-                 M_Item_Glow(8, automap_scheme ? GLOW_GREEN : GLOW_DARKRED));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 108, str,
+                 M_Item_Glow(9, automap_scheme ? GLOW_GREEN : GLOW_DARKRED));
 
     // Smooth lines
     sprintf(str, automap_smooth ? "ON" : "OFF");
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 108, str,
-                 M_Item_Glow(9, automap_smooth ? GLOW_GREEN : GLOW_DARKRED));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 117, str,
+                 M_Item_Glow(10, automap_smooth ? GLOW_GREEN : GLOW_DARKRED));
 
     // Mark secret sectors
     sprintf(str, automap_secrets ? "ON" : "OFF");
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 117, str,
-                 M_Item_Glow(10, automap_secrets ? GLOW_GREEN : GLOW_DARKRED));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 126, str,
+                 M_Item_Glow(11, automap_secrets ? GLOW_GREEN : GLOW_DARKRED));
 
     // Rotate mode
     sprintf(str, automap_rotate ? "ON" : "OFF");
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 126, str,
-                 M_Item_Glow(11, automap_rotate ? GLOW_GREEN : GLOW_DARKRED));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 135, str,
+                 M_Item_Glow(12, automap_rotate ? GLOW_GREEN : GLOW_DARKRED));
 
     // Overlay mode
     sprintf(str, automap_overlay ? "ON" : "OFF");
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 135, str,
-                 M_Item_Glow(12, automap_overlay ? GLOW_GREEN : GLOW_DARKRED));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 144, str,
+                 M_Item_Glow(13, automap_overlay ? GLOW_GREEN : GLOW_DARKRED));
 
     // Overlay shading level
     sprintf(str,"%d", automap_shading);
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 144, str,
-                 M_Item_Glow(13, !automap_overlay ? GLOW_DARKRED :
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 153, str,
+                 M_Item_Glow(14, !automap_overlay ? GLOW_DARKRED :
                                   automap_shading ? GLOW_GREEN : GLOW_RED));
 }
 
@@ -3007,6 +3014,11 @@ static void M_ID_Widget_Time (int choice)
 static void M_ID_Widget_TotalTime (int choice)
 {
     widget_totaltime = M_INT_Slider(widget_totaltime, 0, 2, choice);
+}
+
+static void M_ID_Widget_LevelName (int choice)
+{
+    widget_levelname ^= 1;
 }
 
 static void M_ID_Widget_Coords (int choice)
@@ -4165,6 +4177,7 @@ static void M_ID_ApplyReset (int key)
     widget_kis = 0;
     widget_time = 0;
     widget_totaltime = 0;
+    widget_levelname = 0;
     widget_coords = 0;
     widget_render = 0;
     widget_health = 0;

--- a/src/id_vars.c
+++ b/src/id_vars.c
@@ -65,6 +65,7 @@ int widget_render = 0;
 int widget_kis = 0;
 int widget_time = 0;
 int widget_totaltime = 0;
+int widget_levelname = 0;
 int widget_health = 0;
 
 // Sound
@@ -170,6 +171,7 @@ void ID_BindVariables (void)
     M_BindIntVariable("widget_kis",                     &widget_kis);
     M_BindIntVariable("widget_time",                    &widget_time);
     M_BindIntVariable("widget_totaltime",               &widget_totaltime);
+    M_BindIntVariable("widget_levelname",               &widget_levelname);
     M_BindIntVariable("widget_health",                  &widget_health);
 
     // Sound

--- a/src/id_vars.h
+++ b/src/id_vars.h
@@ -65,6 +65,7 @@ extern int widget_render;
 extern int widget_kis;
 extern int widget_time;
 extern int widget_totaltime;
+extern int widget_levelname;
 extern int widget_health;
 
 // Sound

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -409,6 +409,7 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_INT(widget_kis),
     CONFIG_VARIABLE_INT(widget_time),
     CONFIG_VARIABLE_INT(widget_totaltime),
+    CONFIG_VARIABLE_INT(widget_levelname),
     CONFIG_VARIABLE_INT(widget_coords),
     CONFIG_VARIABLE_INT(widget_render),
     CONFIG_VARIABLE_INT(widget_health),


### PR DESCRIPTION
This widget didn't make a final cut in 7.0 release. Not really useful commonly, but pretty nice for demo watching.