### PR TITLE
Disable rendering of player view while in Video Options menu

### DIFF
--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -82,12 +82,6 @@ int oldleveltime; // [crispy] check if leveltime keeps tickin'
 // [JN] used by player, render and interpolation. Always ticking.
 int realleveltime;
 
-// [JN] Forcefully supress interpolation in video options menu.
-// Needed for render will be able to do a proper update on
-// toggling resolution/widescreen modes.
-
-boolean force_capped_fps;
-
 // When set to true, a single tic is run each time TryRunTics() is called.
 // This is used for -timedemo mode.
 
@@ -703,7 +697,7 @@ void TryRunTics (void)
     //      to run, return early instead of waiting around.
     // [JN] CRL - Keep uncapped framerate while paused and Spectator mode.
     extern boolean paused;
-    #define return_early (vid_uncapped_fps &&!force_capped_fps && counts == 0 && \
+    #define return_early (vid_uncapped_fps && counts == 0 && \
                          ((paused && crl_spectating) || realleveltime > oldleveltime) && \
                          screenvisible)
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -68,7 +68,7 @@ boolean menuactive;
 static int quickSaveSlot;
 
  // 1 = message to be printed
-static int messageToPrint;
+int messageToPrint;
 // ...and here is the message string!
 static const char *messageString;
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -117,51 +117,15 @@ static char savegamestrings[10][SAVESTRINGSIZE];
 static char endstring[160];
 
 
-//
-// MENU TYPEDEFS
-//
-
 // [JN] Macro definitions for first two items of menuitem_t.
 // Trailing zero initializes "tics" field.
 #define M_SKIP -1,0  // Skippable, cursor can't get here.
 #define M_SWTC  1,0  // On/off type or entering function.
 #define M_LFRT  2,0  // Multichoice function.
 
-typedef struct
-{
-    // 0 = no cursor here, 1 = ok, 2 = arrows ok
-    short	status;
-
-    // [JN] Menu item timer for glowing effect.
-    short   tics;
-    
-    char	name[32];
-    
-    // choice = menu item #.
-    // if status = 2,
-    //   choice=0:leftarrow,1:rightarrow
-    void	(*routine)(int choice);
-    
-    // hotkey in menu
-    char	alphaKey;			
-} menuitem_t;
-
-
 // [JN] Small cursor timer for glowing effect.
 static short   cursor_tics = 0;
 static boolean cursor_direction = false;
-
-typedef struct menu_s
-{
-    short		numitems;	// # of menu items
-    struct menu_s*	prevMenu;	// previous menu
-    menuitem_t*		menuitems;	// menu items
-    void		(*routine)(void);	// draw routine
-    short		x;
-    short		y;		// x,y of menu
-    short		lastOn;		// last item user was on in menu
-    boolean		smallFont;  // [JN] If true, use small font
-} menu_t;
 
 static short itemOn;            // menu item skull is on
 static short skullAnimCounter;  // skull animation counter
@@ -172,7 +136,7 @@ static short whichSkull;        // which skull to draw
 static char *skullName[2] = {"M_SKULL1","M_SKULL2"};
 
 // current menudef
-static menu_t *currentMenu;
+menu_t *currentMenu;
 
 // =============================================================================
 // PROTOTYPES
@@ -1079,7 +1043,7 @@ static menuitem_t ID_Menu_Video[]=
     { M_SKIP, "", 0, '\0'}
 };
 
-static menu_t ID_Def_Video =
+menu_t ID_Def_Video =
 {
     m_id_end,
     &ID_Def_Main,
@@ -1099,12 +1063,9 @@ static void M_Draw_ID_Video (void)
 {
     static char str[32];
 
-    // [JN] Forcefully supress interpolation in video options menu.
-    // Needed for render will be able to do a proper update on
-    // toggling resolution/widescreen modes.
-    force_capped_fps = true;
-
-    M_ShadeBackground();
+    // [JN] Note: along with background filling, 
+    // game render is disabled in R_RenderPlayerView.
+    M_FillBackground();
 
     M_WriteTextCentered(18, "VIDEO OPTIONS", cr[CR_YELLOW]);
 
@@ -4267,7 +4228,6 @@ static void M_ID_ApplyReset (int key)
 
 static void M_Choose_ID_Reset (int choice)
 {
-	force_capped_fps = true;
 	M_StartMessage(DEH_String(ID_RESET), M_ID_ApplyReset, true);
 }
 
@@ -6197,9 +6157,6 @@ void M_Ticker (void)
 	whichSkull ^= 1;
 	skullAnimCounter = 8;
     }
-
-    // [JN] Disable interpolation supressing, made in M_Draw_ID_Video.
-    force_capped_fps = false;
 
     // [JN] Menu glowing animation:
     

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -469,13 +469,13 @@ static void M_ID_LimitFPS (int choice);
 static void M_ID_VSync (int choice);
 static void M_ID_ShowFPS (int choice);
 static void M_ID_PixelScaling (int choice);
-static void M_ID_Gamma (int choice);
 static void M_ID_ScreenWipe (int choice);
 static void M_ID_DiskIcon (int choice);
 static void M_ID_ShowENDOOM (int choice);
 
 static void M_Choose_ID_Display (int choice);
 static void M_Draw_ID_Display (void);
+static void M_ID_Gamma (int choice);
 static void M_ID_MenuShading (int choice);
 static void M_ID_LevelBrightness (int choice);
 static void M_ID_MessagesAlignment (int choice);
@@ -1033,13 +1033,12 @@ static menuitem_t ID_Menu_Video[]=
     { M_LFRT, "ENABLE VSYNC",          M_ID_VSync,          'e'},
     { M_LFRT, "SHOW FPS COUNTER",      M_ID_ShowFPS,        's'},
     { M_LFRT, "PIXEL SCALING",         M_ID_PixelScaling,   'p'},
-    { M_LFRT, "GAMMA-CORRECTION",      M_ID_Gamma,          'g'},
-    { M_SKIP, "", 0, '\0'},
-    { M_SKIP, "", 0, '\0'},
     { M_SKIP, "", 0, '\0'},
     { M_LFRT, "SCREEN WIPE EFFECT",    M_ID_ScreenWipe,     's'},
     { M_LFRT, "SHOW DISK ICON",        M_ID_DiskIcon,       's'},
     { M_LFRT, "SHOW ENDOOM SCREEN",    M_ID_ShowENDOOM,     's'},
+    { M_SKIP, "", 0, '\0'},
+    { M_SKIP, "", 0, '\0'},
     { M_SKIP, "", 0, '\0'}
 };
 
@@ -1121,29 +1120,24 @@ static void M_Draw_ID_Video (void)
     M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 90, str, 
                  M_Item_Glow(7, vid_smooth_scaling ? GLOW_GREEN : GLOW_RED));
 
-    // Gamma-correction slider and num
-    M_DrawThermo(46, 108, 15, vid_gamma);
-    M_WriteText (184, 110, gammalvls[vid_gamma][1],
-                           M_Item_Glow(8, GLOW_UNCOLORED));
-
-    M_WriteTextCentered(126, "MISCELLANEOUS", cr[CR_YELLOW]);
+    M_WriteTextCentered(99, "MISCELLANEOUS", cr[CR_YELLOW]);
 
     // Screen wipe effect
     sprintf(str, vid_screenwipe == 1 ? "ORIGINAL" :
                  vid_screenwipe == 2 ? "FAST" : "OFF");
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 135, str,
-                 M_Item_Glow(12, vid_screenwipe ? GLOW_GREEN : GLOW_DARKRED));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 108, str,
+                 M_Item_Glow(9, vid_screenwipe ? GLOW_GREEN : GLOW_DARKRED));
 
     // Show disk icon
     sprintf(str, vid_diskicon == 1 ? "BOTTOM" :
                  vid_diskicon == 2 ? "TOP" : "OFF");
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 144, str, 
-                 M_Item_Glow(13, vid_diskicon ? GLOW_GREEN : GLOW_DARKRED));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 117, str, 
+                 M_Item_Glow(10, vid_diskicon ? GLOW_GREEN : GLOW_DARKRED));
 
     // Show ENDOOM screen
     sprintf(str, vid_endoom ? "ON" : "OFF");
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 153, str, 
-                 M_Item_Glow(14, vid_endoom ? GLOW_GREEN : GLOW_DARKRED));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 126, str, 
+                 M_Item_Glow(11, vid_endoom ? GLOW_GREEN : GLOW_DARKRED));
 }
 
 
@@ -1273,32 +1267,6 @@ static void M_ID_PixelScaling (int choice)
     R_ExecuteSetViewSize();
 }
 
-static void M_ID_Gamma (int choice)
-{
-    shade_wait = I_GetTime() + 25;
-
-    switch (choice)
-    {
-        case 0:
-            if (vid_gamma)
-                vid_gamma--;
-            break;
-        case 1:
-            if (vid_gamma < 14)
-                vid_gamma++;
-        default:
-            break;
-    }
-
-#ifndef CRISPY_TRUECOLOR
-    I_SetPalette ((byte *)W_CacheLumpName(DEH_String("PLAYPAL"), PU_CACHE) + st_palette * 768);
-#else
-    I_SetPalette (st_palette);
-    R_InitColormaps();
-    R_FillBackScreen();
-#endif
-}
-
 static void M_ID_ScreenWipe (int choice)
 {
     vid_screenwipe = M_INT_Slider(vid_screenwipe, 0, 2, choice);
@@ -1321,6 +1289,9 @@ static void M_ID_ShowENDOOM (int choice)
 
 static menuitem_t ID_Menu_Display[]=
 {
+    { M_LFRT, "GAMMA-CORRECTION",         M_ID_Gamma,              'g'},
+    { M_SKIP, "", 0, '\0'},
+    { M_SKIP, "", 0, '\0'},
     { M_LFRT, "MENU BACKGROUND SHADING",  M_ID_MenuShading,        'm'},
     { M_LFRT, "EXTRA LEVEL BRIGHTNESS",   M_ID_LevelBrightness,    'e'},
     { M_SKIP, "", 0, '\0'}, // COLOR SETTINGS
@@ -1332,10 +1303,7 @@ static menuitem_t ID_Menu_Display[]=
     { M_LFRT, "MESSAGES ENABLED",         M_ChangeMessages,        'm'},
     { M_LFRT, "MESSAGES ALIGNMENT",       M_ID_MessagesAlignment,  'm'},
     { M_LFRT, "TEXT CASTS SHADOWS",       M_ID_TextShadows,        't'},
-    { M_LFRT, "LOCAL TIME",               M_ID_LocalTime,          'l'},
-    { M_SKIP, "", 0, '\0'},
-    { M_SKIP, "", 0, '\0'},
-    { M_SKIP, "", 0, '\0'}
+    { M_LFRT, "LOCAL TIME",               M_ID_LocalTime,          'l'}
 };
 
 static menu_t ID_Def_Display =
@@ -1362,63 +1330,68 @@ static void M_Draw_ID_Display (void)
 
     M_WriteTextCentered(18, "DISPLAY OPTIONS", cr[CR_YELLOW]);
 
+    // Gamma-correction slider and num
+    M_DrawThermo(46, 36, 15, vid_gamma);
+    M_WriteText (184, 39, gammalvls[vid_gamma][1],
+                          M_Item_Glow(0, GLOW_UNCOLORED));
+
     // Background shading
     sprintf(str,"%d", dp_menu_shading);
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 27, str,
-                 M_Item_Glow(0, dp_menu_shading == 8 ? GLOW_YELLOW :
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 52, str,
+                 M_Item_Glow(3, dp_menu_shading == 8 ? GLOW_YELLOW :
                                 dp_menu_shading >  0 ? GLOW_GREEN  : GLOW_RED));
 
     // Extra level brightness
     sprintf(str,"%d", dp_level_brightness);
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 36, str,
-                 M_Item_Glow(1, dp_level_brightness == 8 ? GLOW_YELLOW :
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 63, str,
+                 M_Item_Glow(4, dp_level_brightness == 8 ? GLOW_YELLOW :
                                 dp_level_brightness >  0 ? GLOW_GREEN  : GLOW_RED));
 
-    M_WriteTextCentered(45, "COLOR SETTINGS", cr[CR_YELLOW]);
+    M_WriteTextCentered(72, "COLOR SETTINGS", cr[CR_YELLOW]);
 
     // Saturation
     M_snprintf(str, 6, "%d%%", vid_saturation);
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 54, str,
-                 M_Item_Glow(3, GLOW_LIGHTGRAY));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 81, str,
+                 M_Item_Glow(6, GLOW_LIGHTGRAY));
 
     // RED intensity
     M_snprintf(str, 6, "%3f", vid_r_intensity);
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 63, str,
-                 M_Item_Glow(4, GLOW_RED));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 90, str,
+                 M_Item_Glow(7, GLOW_RED));
 
     // GREEN intensity
     M_snprintf(str, 6, "%3f", vid_g_intensity);
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 72, str,
-                 M_Item_Glow(5, GLOW_GREEN));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 99, str,
+                 M_Item_Glow(8, GLOW_GREEN));
 
     // BLUE intensity
     M_snprintf(str, 6, "%3f", vid_b_intensity);
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 81, str,
-                 M_Item_Glow(6, GLOW_BLUE));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 108, str,
+                 M_Item_Glow(9, GLOW_BLUE));
 
-    M_WriteTextCentered(90, "MESSAGES SETTINGS", cr[CR_YELLOW]);
+    M_WriteTextCentered(117, "MESSAGES SETTINGS", cr[CR_YELLOW]);
 
     // Messages enabled
     sprintf(str, showMessages ? "ON" : "OFF");
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 99, str,
-                 M_Item_Glow(8, showMessages ? GLOW_GREEN : GLOW_DARKRED));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 126, str,
+                 M_Item_Glow(11, showMessages ? GLOW_GREEN : GLOW_DARKRED));
 
     // Messages alignment
     sprintf(str, msg_alignment == 1 ? "STATUS BAR" :
                  msg_alignment == 2 ? "CENTERED" : "LEFT");
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 108, str,
-                 M_Item_Glow(9, GLOW_GREEN));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 135, str,
+                 M_Item_Glow(12, GLOW_GREEN));
 
     // Text casts shadows
     sprintf(str, msg_text_shadows ? "ON" : "OFF");
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 117, str, 
-                 M_Item_Glow(10, msg_text_shadows ? GLOW_GREEN : GLOW_DARKRED));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 144, str, 
+                 M_Item_Glow(13, msg_text_shadows ? GLOW_GREEN : GLOW_DARKRED));
 
     // Local time
     sprintf(str, msg_local_time == 1 ? "12-HOUR FORMAT" :
                  msg_local_time == 2 ? "24-HOUR FORMAT" : "OFF");
-    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 126, str, 
-                 M_Item_Glow(11, msg_local_time ? GLOW_GREEN : GLOW_DARKRED));
+    M_WriteText (ID_MENU_RIGHTOFFSET - M_StringWidth(str), 153, str, 
+                 M_Item_Glow(14, msg_local_time ? GLOW_GREEN : GLOW_DARKRED));
 }
 
 static void M_ID_MenuShading (int choice)
@@ -1451,6 +1424,32 @@ static void M_ID_LevelBrightness (int choice)
         default:
             break;
     }
+}
+
+static void M_ID_Gamma (int choice)
+{
+    shade_wait = I_GetTime() + 25;
+
+    switch (choice)
+    {
+        case 0:
+            if (vid_gamma)
+                vid_gamma--;
+            break;
+        case 1:
+            if (vid_gamma < 14)
+                vid_gamma++;
+        default:
+            break;
+    }
+
+#ifndef CRISPY_TRUECOLOR
+    I_SetPalette ((byte *)W_CacheLumpName(DEH_String("PLAYPAL"), PU_CACHE) + st_palette * 768);
+#else
+    I_SetPalette (st_palette);
+    R_InitColormaps();
+    R_FillBackScreen();
+#endif
 }
 
 static void M_ID_MessagesAlignment (int choice)

--- a/src/doom/m_menu.h
+++ b/src/doom/m_menu.h
@@ -25,6 +25,46 @@
 
 #include "d_event.h"
 
+
+//
+// MENU TYPEDEFS
+//
+
+typedef struct
+{
+    // 0 = no cursor here, 1 = ok, 2 = arrows ok
+    short	status;
+
+    // [JN] Menu item timer for glowing effect.
+    short   tics;
+    
+    char	name[32];
+    
+    // choice = menu item #.
+    // if status = 2,
+    //   choice=0:leftarrow,1:rightarrow
+    void	(*routine)(int choice);
+    
+    // hotkey in menu
+    char	alphaKey;			
+} menuitem_t;
+
+typedef struct menu_s
+{
+    short		numitems;	// # of menu items
+    struct menu_s*	prevMenu;	// previous menu
+    menuitem_t*		menuitems;	// menu items
+    void		(*routine)(void);	// draw routine
+    short		x;
+    short		y;		// x,y of menu
+    short		lastOn;		// last item user was on in menu
+    boolean		smallFont;  // [JN] If true, use small font
+} menu_t;
+
+// [JN] Externalized for R_RenderPlayerView.
+extern menu_t *currentMenu;
+extern menu_t ID_Def_Video;
+
 //
 // MENUS
 //

--- a/src/doom/m_menu.h
+++ b/src/doom/m_menu.h
@@ -62,8 +62,9 @@ typedef struct menu_s
 } menu_t;
 
 // [JN] Externalized for R_RenderPlayerView.
+extern int     messageToPrint;
 extern menu_t *currentMenu;
-extern menu_t ID_Def_Video;
+extern menu_t  ID_Def_Video;
 
 //
 // MENUS

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -1054,7 +1054,7 @@ void R_RenderPlayerView (player_t *player)
 {
     // [JN] Disable rendering while in Video Options menu
     // to prevent possible crashes on rendering resolution toggling.
-    if (menuactive && currentMenu == &ID_Def_Video)
+    if (menuactive && currentMenu == &ID_Def_Video && !messageToPrint)
     {
         return;
     }

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -1052,6 +1052,13 @@ void R_SetupFrame (player_t* player)
 //
 void R_RenderPlayerView (player_t *player)
 {
+    // [JN] Disable rendering while in Video Options menu
+    // to prevent possible crashes on rendering resolution toggling.
+    if (menuactive && currentMenu == &ID_Def_Video)
+    {
+        return;
+    }
+
     // [JN] Reset render counters.
     memset(&IDRender, 0, sizeof(IDRender));
 


### PR DESCRIPTION
This should fix possible `R_MapPlane` error while toggling rendering resolution. Previous approach was to cap framerate to 35 fps while in Video Options, but turns out it was not optimal. Not sure what's the _real_ nature of this error, though. 

Many thanks to @MrAlaux for pointing out that it still can happen!