### PR TITLE
Separate platform-dependent source files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,7 +100,7 @@ if(WIN32)
     list(APPEND GAME_SOURCE_FILES i_winmusic.c)
     list(APPEND GAME_SOURCE_FILES midifallback.c    midifallback.h)
     list(APPEND GAME_SOURCE_FILES w_file_win32.c)
-else()
+elseif(POSIX)
     list(APPEND GAME_SOURCE_FILES w_file_posix.c)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,9 +58,7 @@ set(GAME_SOURCE_FILES
     i_sound.c           i_sound.h
     i_timer.c           i_timer.h
     i_video.c           i_video.h
-    i_winmusic.c
     id_vars.c           id_vars.h
-    midifallback.c      midifallback.h
     midifile.c          midifile.h
     mus2mid.c           mus2mid.h
     m_bbox.c            m_bbox.h
@@ -99,9 +97,11 @@ set(GAME_SOURCE_FILES
 # Platform-dependent source files:
 
 if(WIN32)
-  list(APPEND GAME_SOURCE_FILES w_file_win32.c)
+    list(APPEND GAME_SOURCE_FILES i_winmusic.c)
+    list(APPEND GAME_SOURCE_FILES midifallback.c    midifallback.h)
+    list(APPEND GAME_SOURCE_FILES w_file_win32.c)
 else()
-  list(APPEND GAME_SOURCE_FILES w_file_posix.c)
+    list(APPEND GAME_SOURCE_FILES w_file_posix.c)
 endif()
 
 set(GAME_INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}/../")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,10 +93,16 @@ set(GAME_SOURCE_FILES
     w_wad.c             w_wad.h
     w_file.c            w_file.h
     w_file_stdc.c
-    w_file_posix.c
-    w_file_win32.c
     w_merge.c           w_merge.h
     z_zone.c            z_zone.h)
+
+# Platform-dependent source files:
+
+if(WIN32)
+  list(APPEND GAME_SOURCE_FILES w_file_win32.c)
+else()
+  list(APPEND GAME_SOURCE_FILES w_file_posix.c)
+endif()
 
 set(GAME_INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}/../")
 


### PR DESCRIPTION
To fix remaining pedantic warnings under GCC.

Co-Authored-By: Roman Fomin <rfomin@gmail.com>
