### PR TITLE
Extend MAXWIDTH/HEIGHT arrays

### DIFF
--- a/src/i_video.h
+++ b/src/i_video.h
@@ -30,7 +30,7 @@
 #define ORIGWIDTH  320 // [crispy]
 #define ORIGHEIGHT 200 // [crispy]
 
-// [JN] Increase more to support quad rendering resolution.
+// [JN] Increase more (+2) to support quad rendering resolution.
 #define MAXWIDTH  (ORIGWIDTH << 5)  // [crispy] 
 #define MAXHEIGHT (ORIGHEIGHT << 4) // [crispy] 
 
@@ -63,6 +63,7 @@ enum
 // Screen height used when vid_aspect_ratio_correct=true.
 
 #define ORIGHEIGHT_4_3 240 // [crispy]
+// [JN] Increase more (+2) to support quad rendering resolution.
 #define MAXHEIGHT_4_3 (ORIGHEIGHT_4_3 << 4) // [crispy]
 
 extern int SCREENHEIGHT_4_3;

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -31,8 +31,8 @@
 #define ORIGHEIGHT 200 // [crispy]
 
 // [JN] Increase more to support quad rendering resolution.
-#define MAXWIDTH  (ORIGWIDTH << 3)  // [crispy] 
-#define MAXHEIGHT (ORIGHEIGHT << 2) // [crispy] 
+#define MAXWIDTH  (ORIGWIDTH << 5)  // [crispy] 
+#define MAXHEIGHT (ORIGHEIGHT << 4) // [crispy] 
 
 extern int SCREENWIDTH;
 extern int SCREENHEIGHT;
@@ -63,7 +63,7 @@ enum
 // Screen height used when vid_aspect_ratio_correct=true.
 
 #define ORIGHEIGHT_4_3 240 // [crispy]
-#define MAXHEIGHT_4_3 (ORIGHEIGHT_4_3 << 1) // [crispy]
+#define MAXHEIGHT_4_3 (ORIGHEIGHT_4_3 << 4) // [crispy]
 
 extern int SCREENHEIGHT_4_3;
 


### PR DESCRIPTION
This fixes rarely random crashes while column drawing (sprites or 2-s transparent walls) on... game loading. What's the nature of this bug? I don't know. Neither GCC/Clang compilers were giving any possible overflow warnings, nor debuggers were showing any clear points all this time.