### PR TITLE
Implement reload / go to next level while demo playing

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -222,7 +222,7 @@ static void D_Display (void)
     // To make it visible, a simplified version of I_FinishUpdate is used.
     // Also, calling it every frame tic is expensive and causes performace
     // penalties, so call it only every 350th frame tic (basically, TICRATE*10).  
-    if (demoplayback && (demowarp || demo_nextlevel))
+    if (demoplayback && demowarp)
     {
         demowarp_count++;
         

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -222,7 +222,7 @@ static void D_Display (void)
     // To make it visible, a simplified version of I_FinishUpdate is used.
     // Also, calling it every frame tic is expensive and causes performace
     // penalties, so call it only every 350th frame tic (basically, TICRATE*10).  
-    if (demoplayback && demowarp)
+    if (demoplayback && (demowarp || demo_nextlevel))
     {
         demowarp_count++;
         

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -3007,29 +3007,30 @@ boolean G_CheckDemoStatus (void)
 } 
  
  
-// -----------------------------------------------------------------------------
+//
+// G_DemoGoToNextLevel
 // [JN] Fast forward to next level while playing demo.
-// -----------------------------------------------------------------------------
+//
 
-boolean demo_nextlevel;
+boolean demo_gotonextlvl;
 
-void G_FastDemoWarpStart (void)
+void G_DemoGoToNextLevel (boolean start)
 {
-    nodrawers = true;
-    
-    if (!timingdemo)
+    if (start)
     {
-        singletics = true;
+        nodrawers = true;
+        if (!timingdemo)
+        {
+            singletics = true;
+        }
     }
-}
-
-void G_FastDemoWarpStop (void)
-{
-    nodrawers = false;
-    
-    if (!timingdemo)
+    else
     {
-        singletics = false;
+        nodrawers = false;
+        if (!timingdemo)
+        {
+            singletics = false;
+        }
     }
 }
  

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -3009,28 +3009,20 @@ boolean G_CheckDemoStatus (void)
  
 //
 // G_DemoGoToNextLevel
-// [JN] Fast forward to next level while playing demo.
+// [JN] Fast forward to next level while demo playback.
 //
 
 boolean demo_gotonextlvl;
 
 void G_DemoGoToNextLevel (boolean start)
 {
-    if (start)
+    // Disable screen rendering while fast forwarding.
+    nodrawers = start;
+
+    // Switch to fast tics running mode if not in -timedemo.
+    if (!timingdemo)
     {
-        nodrawers = true;
-        if (!timingdemo)
-        {
-            singletics = true;
-        }
-    }
-    else
-    {
-        nodrawers = false;
-        if (!timingdemo)
-        {
-            singletics = false;
-        }
+        singletics = start;
     }
 }
  

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -3007,4 +3007,29 @@ boolean G_CheckDemoStatus (void)
 } 
  
  
+// -----------------------------------------------------------------------------
+// [JN] Fast forward to next level while playing demo.
+// -----------------------------------------------------------------------------
+
+boolean demo_nextlevel;
+
+void G_FastDemoWarpStart (void)
+{
+    nodrawers = true;
+    
+    if (!timingdemo)
+    {
+        singletics = true;
+    }
+}
+
+void G_FastDemoWarpStop (void)
+{
+    nodrawers = false;
+    
+    if (!timingdemo)
+    {
+        singletics = false;
+    }
+}
  

--- a/src/doom/g_game.h
+++ b/src/doom/g_game.h
@@ -62,3 +62,8 @@ extern void G_Ticker (void);
 extern void G_TimeDemo (char *name);
 extern void G_WorldDone (void);
 extern void G_WriteDemoTiccmd (ticcmd_t *cmd); 
+
+// [JN] Fast forward to next level while playing demo.
+extern boolean demo_nextlevel;
+extern void G_FastDemoWarpStart (void);
+extern void G_FastDemoWarpStop (void);

--- a/src/doom/g_game.h
+++ b/src/doom/g_game.h
@@ -65,6 +65,5 @@ extern void G_WriteDemoTiccmd (ticcmd_t *cmd);
 
 // [JN] Fast forward to next level while playing demo.
 extern boolean netdemo; 
-extern boolean demo_nextlevel;
-extern void G_FastDemoWarpStart (void);
-extern void G_FastDemoWarpStop (void);
+extern boolean demo_gotonextlvl;
+extern void G_DemoGoToNextLevel (boolean start);

--- a/src/doom/g_game.h
+++ b/src/doom/g_game.h
@@ -64,6 +64,7 @@ extern void G_WorldDone (void);
 extern void G_WriteDemoTiccmd (ticcmd_t *cmd); 
 
 // [JN] Fast forward to next level while playing demo.
+extern boolean netdemo; 
 extern boolean demo_nextlevel;
 extern void G_FastDemoWarpStart (void);
 extern void G_FastDemoWarpStop (void);

--- a/src/doom/g_game.h
+++ b/src/doom/g_game.h
@@ -63,7 +63,7 @@ extern void G_TimeDemo (char *name);
 extern void G_WorldDone (void);
 extern void G_WriteDemoTiccmd (ticcmd_t *cmd); 
 
-// [JN] Fast forward to next level while playing demo.
+// [JN] Fast forward to next level while demo playback.
 extern boolean netdemo; 
 extern boolean demo_gotonextlvl;
 extern void G_DemoGoToNextLevel (boolean start);

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -5779,7 +5779,7 @@ boolean M_Responder (event_t* ev)
         {
             if (demoplayback)
             {
-                // [JN] Reload demo lump / file.
+                // [JN] Replay demo lump or file.
                 G_DoPlayDemo();
                 return true;
             }
@@ -5791,7 +5791,7 @@ boolean M_Responder (event_t* ev)
         {
             if (demoplayback)
             {
-                // [JN] Go to next level while playing demo.
+                // [JN] Go to next level.
                 demo_gotonextlvl = true;
                 G_DemoGoToNextLevel(true);
                 return true;

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -5779,7 +5779,7 @@ boolean M_Responder (event_t* ev)
         {
             if (demoplayback)
             {
-                // [JN] Reload demo.
+                // [JN] Reload demo lump / file.
                 G_DoPlayDemo();
                 return true;
             }
@@ -5792,8 +5792,8 @@ boolean M_Responder (event_t* ev)
             if (demoplayback)
             {
                 // [JN] Go to next level while playing demo.
-                demo_nextlevel = true;
-                G_FastDemoWarpStart();
+                demo_gotonextlvl = true;
+                G_DemoGoToNextLevel(true);
                 return true;
             }
             else

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -5779,7 +5779,7 @@ boolean M_Responder (event_t* ev)
             if (G_ReloadLevel())
             return true;
         }
-        else if (!netgame && key != 0 && key == key_nextlevel)
+        else if ((!netgame || netdemo) && key != 0 && key == key_nextlevel)
         {
             if (demoplayback)
             {

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -5774,8 +5774,16 @@ boolean M_Responder (event_t* ev)
         }
         // [crispy] those two can be considered as shortcuts for the IDCLEV cheat
         // and should be treated as such, i.e. add "if (!netgame)"
-        else if (!netgame && key != 0 && key == key_reloadlevel)
+        // [JN] Hovewer, allow while multiplayer demos.
+        else if ((!netgame || netdemo) && key != 0 && key == key_reloadlevel)
         {
+            if (demoplayback)
+            {
+                // [JN] Reload demo.
+                G_DoPlayDemo();
+                return true;
+            }
+            else
             if (G_ReloadLevel())
             return true;
         }

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -5781,6 +5781,14 @@ boolean M_Responder (event_t* ev)
         }
         else if (!netgame && key != 0 && key == key_nextlevel)
         {
+            if (demoplayback)
+            {
+                // [JN] Go to next level while playing demo.
+                demo_nextlevel = true;
+                G_FastDemoWarpStart();
+                return true;
+            }
+            else
             if (G_GotoNextLevel())
             return true;
         }

--- a/src/doom/p_mobj.c
+++ b/src/doom/p_mobj.c
@@ -956,6 +956,13 @@ void P_SpawnPlayer (mapthing_t* mthing)
 
     int			i;
 
+    // [JN] Stop fast forward after entering new level while demo playback.
+    if (demo_gotonextlvl)
+    {
+        demo_gotonextlvl = false;
+        G_DemoGoToNextLevel(false);
+    }
+
     if (mthing->type == 0)
     {
         return;
@@ -965,13 +972,6 @@ void P_SpawnPlayer (mapthing_t* mthing)
     if (!playeringame[mthing->type-1])
 	return;					
 		
-    // [JN] Stop fast forward after entering new level while demo playing.
-    if (demo_gotonextlvl)
-    {
-        demo_gotonextlvl = false;
-        G_DemoGoToNextLevel(false);
-    }
-
     p = &players[mthing->type-1];
 
     if (p->playerstate == PST_REBORN)

--- a/src/doom/p_mobj.c
+++ b/src/doom/p_mobj.c
@@ -966,10 +966,10 @@ void P_SpawnPlayer (mapthing_t* mthing)
 	return;					
 		
     // [JN] Stop fast forward after entering new level while demo playing.
-    if (demo_nextlevel)
+    if (demo_gotonextlvl)
     {
-        demo_nextlevel = false;
-        G_FastDemoWarpStop();
+        demo_gotonextlvl = false;
+        G_DemoGoToNextLevel(false);
     }
 
     p = &players[mthing->type-1];

--- a/src/doom/p_mobj.c
+++ b/src/doom/p_mobj.c
@@ -965,6 +965,13 @@ void P_SpawnPlayer (mapthing_t* mthing)
     if (!playeringame[mthing->type-1])
 	return;					
 		
+    // [JN] Stop fast forward after entering new level while demo playing.
+    if (demo_nextlevel)
+    {
+        demo_nextlevel = false;
+        G_FastDemoWarpStop();
+    }
+
     p = &players[mthing->type-1];
 
     if (p->playerstate == PST_REBORN)

--- a/src/doom/s_sound.c
+++ b/src/doom/s_sound.c
@@ -38,6 +38,7 @@
 #include "p_local.h"
 #include "w_wad.h"
 #include "z_zone.h"
+#include "g_game.h"  // [JN] demo_nextlevel
 
 #include "id_vars.h"
 #include "id_func.h"
@@ -816,7 +817,7 @@ void S_ChangeMusic(int musicnum, int looping)
     void *handle;
 
     // [JN] Do not play music while demo-warp.
-    if (nodrawers || demowarp)
+    if ((nodrawers || demowarp) && !demo_nextlevel)
     {
         return;
     }

--- a/src/doom/s_sound.c
+++ b/src/doom/s_sound.c
@@ -817,7 +817,7 @@ void S_ChangeMusic(int musicnum, int looping)
     void *handle;
 
     // [JN] Do not play music while demo-warp,
-    // but still change while warping to next level.
+    // but still change while fast forwarding to next level in demo playback.
     if ((nodrawers || demowarp) && !demo_gotonextlvl)
     {
         return;

--- a/src/doom/s_sound.c
+++ b/src/doom/s_sound.c
@@ -38,7 +38,7 @@
 #include "p_local.h"
 #include "w_wad.h"
 #include "z_zone.h"
-#include "g_game.h"  // [JN] demo_nextlevel
+#include "g_game.h"  // [JN] demo_gotonextlvl
 
 #include "id_vars.h"
 #include "id_func.h"
@@ -816,8 +816,9 @@ void S_ChangeMusic(int musicnum, int looping)
     char namebuf[9];
     void *handle;
 
-    // [JN] Do not play music while demo-warp.
-    if ((nodrawers || demowarp) && !demo_nextlevel)
+    // [JN] Do not play music while demo-warp,
+    // but still change while warping to next level.
+    if ((nodrawers || demowarp) && !demo_gotonextlvl)
     {
         return;
     }


### PR DESCRIPTION
@fabiangreffrath, @rfomin, this is an extremely straightforward implementation, inspired by Woof, but probably slightly different since I wanted to understand how to do this on my own. Interestingly, jumping to the next level feels slightly faster than in Woof, probably because I'm not using `I_FinishUpdate` for the smooth drawing demo bar, but the difference is barely noticeable, it's only about a couple of milliseconds. Could it be useful for Crispy Doom, where these two keys just stop the demo playback?

Few thoughts:
- Function and `demo_nextlevel` boolean names. Not sure they fits well, needs more thinking to make them more consistent with original code.
- Code styling. Needs some polishing as well, especially in `g_game.c` to "mimic" original id Software style, but that's not a big deal.
- Then again, what's about smooth demo bar drawing? Do we want faster jumping (current implementation), or do we want smooth demo bar drawing (most likely will require some extra job in `I_FinishUpdate`)? I have a [small hack](https://github.com/JNechaevsky/international-doom/blob/main/src/i_video.c#L1048-L1070) to draw demo bar while using `-warp` in demo playback, but not sure I want to suggest it at all.