### PR TITLE
Add support for 5x (1000p) and 6x (1200p) rendering resolutions

### DIFF
--- a/src/d_loop.c
+++ b/src/d_loop.c
@@ -77,6 +77,7 @@ static int recvtic;
 // The number of tics that have been run (using RunTic) so far.
 
 int gametic;
+int oldgametic;   // [JN] Invoke certain actions independently from uncapped framerate.
 int oldleveltime; // [crispy] check if leveltime keeps tickin'
 
 // [JN] used by player, render and interpolation. Always ticking.

--- a/src/d_loop.h
+++ b/src/d_loop.h
@@ -79,6 +79,7 @@ void D_StartNetGame(net_gamesettings_t *settings,
 
 extern boolean singletics;
 extern int gametic, ticdup;
+extern int oldgametic;   // [JN] Invoke certain actions independently from uncapped framerate.
 extern int oldleveltime; // [crispy] check if leveltime keeps tickin'
 
 // Check if it is permitted to record a demo with a non-vanilla feature.

--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -1142,7 +1142,10 @@ static void AM_clearFB(int color)
 
 static void AM_shadeBackground (void)
 {
-        for (int y = 0; y < SCREENWIDTH * SCREENHEIGHT - ST_HEIGHT ; y++)
+    const int height = dp_screen_size > 10 ?
+                       SCREENHEIGHT : (SCREENHEIGHT - (ST_HEIGHT * vid_resolution));
+
+        for (int y = 0; y < SCREENWIDTH * height ; y++)
         {
 #ifndef CRISPY_TRUECOLOR
             I_VideoBuffer[y] = colormaps[((automap_shading + 3) * 2) * 256 + I_VideoBuffer[y]];

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -363,7 +363,14 @@ static void D_Display (void)
         // [JN] Main status bar drawing function.
         if (dp_screen_size < 15 || (automapactive && !automap_overlay))
         {
-            ST_Drawer();
+            // [JN] Only forcefully update/redraw on...
+            const boolean st_forceredraw = 
+                             (oldgametic < gametic             // Every game tic
+                          ||  dp_screen_size > 10              // Crispy HUD (no solid status bar background)
+                          ||  setsizeneeded                    // Screen size changing
+                          || (menuactive && dp_menu_shading)); // Active menu and background shading effect
+
+            ST_Drawer(st_forceredraw);
         }
 
         // [JN] Chat drawer
@@ -503,8 +510,6 @@ boolean D_GrabMouseCallback(void)
 //
 void D_DoomLoop (void)
 {
-    static int oldgametic;
-
     if (gamevariant == bfgedition &&
         (demorecording || (gameaction == ga_playdemo) || netgame))
     {

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -279,6 +279,12 @@ static void D_Display (void)
         R_RenderPlayerView(&players[displayplayer]);
     }
 
+    // [JN] Fail-safe: return earlier if post rendering hook is still active.
+    if (post_rendering_hook)
+    {
+        return;
+    }
+
     // clean up border stuff
     if (gamestate != oldgamestate && gamestate != GS_LEVEL)
 #ifndef CRISPY_TRUECOLOR

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1295,7 +1295,7 @@ static void M_ID_RenderingResHook (void)
 
 static void M_ID_RenderingRes (int choice)
 {
-    vid_resolution = M_INT_Slider(vid_resolution, 1, 6, choice);
+    vid_resolution = M_INT_Slider(vid_resolution, 1, MAXHIRES, choice);
     post_rendering_hook = M_ID_RenderingResHook;
 }
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1171,13 +1171,20 @@ static void M_Draw_ID_Video (void)
 #endif
 
     // Rendering resolution
-    sprintf(str, vid_resolution == 2 ? "DOUBLE" :
-                 vid_resolution == 3 ? "TRIPLE" :
-                 vid_resolution == 4 ? "QUAD"   : "ORIGINAL");
+    sprintf(str, vid_resolution == 1 ? "1X (200P)"  :
+                 vid_resolution == 2 ? "2X (400P)"  :
+                 vid_resolution == 3 ? "3X (600P)"  :
+                 vid_resolution == 4 ? "4X (800P)"  :
+                 vid_resolution == 5 ? "5X (1000P)" :
+                 vid_resolution == 6 ? "6X (1200P)" :
+                                       "CUSTOM");
     M_WriteText (M_ItemRightAlign(str), 36, str, 
-                 M_Item_Glow(1, vid_resolution == 2 ? GLOW_GREEN  :
-                                vid_resolution == 3 ? GLOW_YELLOW : 
-                                vid_resolution == 4 ? GLOW_ORANGE : GLOW_DARKRED));
+                 M_Item_Glow(1, vid_resolution == 1 ? GLOW_DARKRED :
+                                vid_resolution == 2 ||
+                                vid_resolution == 3 ? GLOW_GREEN :
+                                vid_resolution == 4 ||
+                                vid_resolution == 5 ? GLOW_YELLOW :
+                                                      GLOW_ORANGE));
 
     // Widescreen rendering
     sprintf(str, vid_widescreen == 1 ? "MATCH SCREEN" :
@@ -1233,6 +1240,20 @@ static void M_Draw_ID_Video (void)
     sprintf(str, vid_endoom ? "ON" : "OFF");
     M_WriteText (M_ItemRightAlign(str), 126, str, 
                  M_Item_Glow(11, vid_endoom ? GLOW_DARKRED : GLOW_GREEN));
+
+    // [JN] Print current resolution. Shamelessly taken from Nugget Doom!
+    if (itemOn == 1 || itemOn == 2)
+    {
+        char  width[8];
+        char  height[8];
+        const char *resolution;
+
+        M_snprintf(width, 8, "%d", (ORIGWIDTH + (WIDESCREENDELTA*2)) * vid_resolution);
+        M_snprintf(height, 8, "%d", ORIGHEIGHT_4_3 * vid_resolution);
+        resolution = M_StringJoin("CURRENT RESOLUTION: ", width, "x", height, NULL);
+
+        M_WriteTextCentered(144, resolution, cr[CR_LIGHTGRAY_DARK1]);
+    }
 }
 
 #ifdef CRISPY_TRUECOLOR
@@ -1274,7 +1295,7 @@ static void M_ID_RenderingResHook (void)
 
 static void M_ID_RenderingRes (int choice)
 {
-    vid_resolution = M_INT_Slider(vid_resolution, 1, 4, choice);
+    vid_resolution = M_INT_Slider(vid_resolution, 1, 6, choice);
     post_rendering_hook = M_ID_RenderingResHook;
 }
 

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -1295,8 +1295,10 @@ static void ST_DrawWeaponNumberFunc (const int val, const int x, const int y, co
 // [JN] Main drawing function, totally rewritten.
 // -----------------------------------------------------------------------------
 
-void ST_Drawer (void)
+void ST_Drawer (boolean force)
 {
+    if (force)
+    {
     // [JN] Wide status bar.
     const int wide_x = dp_screen_size > 12 && (!automapactive || automap_overlay) ?
                        WIDESCREENDELTA : 0;
@@ -1485,6 +1487,7 @@ void ST_Drawer (void)
     ST_DrawSmallNumberY(plyr->maxammo[1], 306 + wide_x, 179);
     ST_DrawSmallNumberY(plyr->maxammo[3], 306 + wide_x, 185);
     ST_DrawSmallNumberY(plyr->maxammo[2], 306 + wide_x, 191);
+    }
 }
 
 typedef void (*load_callback_t)(const char *lumpname, patch_t **variable); 

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -1650,6 +1650,6 @@ void ST_Start (void)
 void ST_Init (void)
 {
     ST_loadData();
-    st_backing_screen = (pixel_t *) Z_Malloc(MAXWIDTH * (ST_HEIGHT << 2)
+    st_backing_screen = (pixel_t *) Z_Malloc(MAXWIDTH * (ST_HEIGHT * MAXHIRES)
                       * sizeof(*st_backing_screen), PU_STATIC, 0);
 }

--- a/src/doom/st_bar.h
+++ b/src/doom/st_bar.h
@@ -44,7 +44,7 @@ boolean ST_Responder (event_t* ev);
 void ST_Ticker (void);
 
 // Called by main loop.
-void ST_Drawer (void);
+void ST_Drawer (boolean force);
 
 // Called when the console player is spawned on each level.
 void ST_Start (void);

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -198,6 +198,13 @@ void D_Display(void)
             }
             else
                 R_RenderPlayerView(&players[displayplayer]);
+
+            // [JN] Fail-safe: return earlier if post rendering hook is still active.
+            if (post_rendering_hook)
+            {
+                return;
+            }
+
             if (automapactive && automap_overlay)
             {
                 AM_Drawer();

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -1086,7 +1086,7 @@ static void M_ID_RenderingResHook (void)
 
 static boolean M_ID_RenderingRes (int choice)
 {
-    vid_resolution = M_INT_Slider(vid_resolution, 1, 6, choice);
+    vid_resolution = M_INT_Slider(vid_resolution, 1, MAXHIRES, choice);
     post_rendering_hook = M_ID_RenderingResHook;
     return true;
 }

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -974,13 +974,20 @@ static void M_Draw_ID_Video (void)
 #endif
 
     // Rendering resolution
-    sprintf(str, vid_resolution == 2 ? "DOUBLE" :
-                 vid_resolution == 3 ? "TRIPLE" :
-                 vid_resolution == 4 ? "QUAD"   : "ORIGINAL");
+    sprintf(str, vid_resolution == 1 ? "1X (200P)"  :
+                 vid_resolution == 2 ? "2X (400P)"  :
+                 vid_resolution == 3 ? "3X (600P)"  :
+                 vid_resolution == 4 ? "4X (800P)"  :
+                 vid_resolution == 5 ? "5X (1000P)" :
+                 vid_resolution == 6 ? "6X (1200P)" :
+                                       "CUSTOM");
     MN_DrTextA(str, M_ItemRightAlign(str), 30,
-               M_Item_Glow(1, vid_resolution == 2 ? GLOW_GREEN  :
-                              vid_resolution == 3 ? GLOW_YELLOW : 
-                              vid_resolution == 4 ? GLOW_ORANGE : GLOW_DARKRED));
+               M_Item_Glow(1, vid_resolution == 1 ? GLOW_DARKRED :
+                              vid_resolution == 2 ||
+                              vid_resolution == 3 ? GLOW_GREEN :
+                              vid_resolution == 4 ||
+                              vid_resolution == 5 ? GLOW_YELLOW :
+                                                    GLOW_ORANGE));
 
     // Widescreen mode
     sprintf(str, vid_widescreen == 1 ? "MATCH SCREEN" :
@@ -1024,6 +1031,20 @@ static void M_Draw_ID_Video (void)
     sprintf(str, vid_endoom ? "ON" : "OFF");
     MN_DrTextA(str, M_ItemRightAlign(str), 110,
                M_Item_Glow(9, vid_endoom ? GLOW_GREEN : GLOW_RED));
+
+    // [JN] Print current resolution. Shamelessly taken from Nugget Doom!
+    if (CurrentItPos == 1 || CurrentItPos == 2)
+    {
+        char  width[8];
+        char  height[8];
+        const char *resolution;
+
+        M_snprintf(width, 8, "%d", (ORIGWIDTH + (WIDESCREENDELTA*2)) * vid_resolution);
+        M_snprintf(height, 8, "%d", ORIGHEIGHT_4_3 * vid_resolution);
+        resolution = M_StringJoin("CURRENT RESOLUTION: ", width, "X", height, NULL);
+
+        MN_DrTextACentered(resolution, 130, cr[CR_LIGHTGRAY_DARK1]);
+    }
 }
 
 #ifdef CRISPY_TRUECOLOR
@@ -1065,7 +1086,7 @@ static void M_ID_RenderingResHook (void)
 
 static boolean M_ID_RenderingRes (int choice)
 {
-    vid_resolution = M_INT_Slider(vid_resolution, 1, 4, choice);
+    vid_resolution = M_INT_Slider(vid_resolution, 1, 6, choice);
     post_rendering_hook = M_ID_RenderingResHook;
     return true;
 }

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -300,7 +300,7 @@ void SB_Init(void)
     spinbooklump = W_GetNumForName(DEH_String("SPINBK0"));
     spinflylump = W_GetNumForName(DEH_String("SPFLY0"));
 
-    st_backing_screen = (pixel_t *) Z_Malloc(MAXWIDTH * (42 << 2) * sizeof(*st_backing_screen), PU_STATIC, 0);
+    st_backing_screen = (pixel_t *) Z_Malloc(MAXWIDTH * (42 * MAXHIRES) * sizeof(*st_backing_screen), PU_STATIC, 0);
 }
 
 //---------------------------------------------------------------------------

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -500,6 +500,7 @@ static void ShadeLine(int x, int y, int height, int shade)
     dest = I_VideoBuffer + y * SCREENWIDTH + x + (WIDESCREENDELTA * vid_resolution);
     while (height--)
     {
+        // [JN] TODO - simplify this mess...
         if (vid_resolution == 2)
         {
 #ifndef CRISPY_TRUECOLOR
@@ -528,6 +529,36 @@ static void ShadeLine(int x, int y, int height, int shade)
             *(dest + 1) = I_BlendDark(*dest, shade);    
             *(dest + 2) = I_BlendDark(*dest, shade);
             *(dest + 3) = I_BlendDark(*dest, shade);
+#endif
+        }
+        if (vid_resolution == 5)
+        {
+#ifndef CRISPY_TRUECOLOR
+            *(dest + 1) = *(shades + *dest);
+            *(dest + 2) = *(shades + *dest);
+            *(dest + 3) = *(shades + *dest);
+            *(dest + 4) = *(shades + *dest);
+#else
+            *(dest + 1) = I_BlendDark(*dest, shade);    
+            *(dest + 2) = I_BlendDark(*dest, shade);
+            *(dest + 3) = I_BlendDark(*dest, shade);
+            *(dest + 4) = I_BlendDark(*dest, shade);
+#endif
+        }
+        if (vid_resolution == 6)
+        {
+#ifndef CRISPY_TRUECOLOR
+            *(dest + 1) = *(shades + *dest);
+            *(dest + 2) = *(shades + *dest);
+            *(dest + 3) = *(shades + *dest);
+            *(dest + 4) = *(shades + *dest);
+            *(dest + 5) = *(shades + *dest);
+#else
+            *(dest + 1) = I_BlendDark(*dest, shade);    
+            *(dest + 2) = I_BlendDark(*dest, shade);
+            *(dest + 3) = I_BlendDark(*dest, shade);
+            *(dest + 4) = I_BlendDark(*dest, shade);
+            *(dest + 5) = I_BlendDark(*dest, shade);
 #endif
         }
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1707,28 +1707,18 @@ void I_GetScreenDimensions (void)
 
 		SCREENWIDTH = w * ah / h;
 		// [crispy] make sure SCREENWIDTH is an integer multiple of 4 ...
-
-		// [FG] For performance reasons, SDL2 insists that the screen pitch,
-		// i.e. the *number of bytes* that one horizontal row of pixels
-		// occupy in memory, must be a multiple of 4.
-		// And for a paletted framebuffer with only one byte per pixel
-		// this means we need to keep the *number of pixels* a multiple of 4.
-		//
-		// Now, in widescreen mode, 240 px * 16 / 9 = 426.7 px.
-		// The widescreen status bar graphic of the Unity port is 426 px wide.
-		// This, however, is not a multiple of 4, so we have to *round up*
-		// to 428 px for it to fit on screen (with one blank px left and right).
-		// In hires mode, 480 px * 16 / 9 = 853.3 px.
-		// In order to fit the widescreen status bar graphic exactly twice on
-		// screen, we *round down* to 2 * 426 px = 852 px.
-
-		while ((SCREENWIDTH * vid_resolution) & 3)
+		if (vid_resolution > 1)
 		{
-			SCREENWIDTH++;
+			// [Nugget] Since we have uneven resolution multipliers, mask it twice
+			SCREENWIDTH = (((SCREENWIDTH * vid_resolution) & (int)~3) / vid_resolution + 3) & (int)~3;
+		}
+		else
+		{
+			SCREENWIDTH = (SCREENWIDTH + 3) & (int)~3;
 		}
 
 		// [crispy] ... but never exceeds MAXWIDTH (array size!)
-		SCREENWIDTH = MIN(SCREENWIDTH, MAXWIDTH / vid_resolution);
+		SCREENWIDTH = MIN(SCREENWIDTH, MAXWIDTH / 3);
 	}
 
 	WIDESCREENDELTA = ((SCREENWIDTH - NONWIDEWIDTH) / vid_resolution) / 2;

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -30,9 +30,12 @@
 #define ORIGWIDTH  320 // [crispy]
 #define ORIGHEIGHT 200 // [crispy]
 
-// [JN] Increase more (+2) to support quad rendering resolution.
+// [JN] Allocate enough to support higher rendering resolutions.
 #define MAXWIDTH  (ORIGWIDTH << 5)  // [crispy] 
 #define MAXHEIGHT (ORIGHEIGHT << 4) // [crispy] 
+
+// [JN] Maximum available rendering resolution.
+#define MAXHIRES 6
 
 extern int SCREENWIDTH;
 extern int SCREENHEIGHT;


### PR DESCRIPTION
In this PR:
* Support for 5x (1000P) and 6x (1200P) rendering resolutions. Technically, 7x and 8x are working via config-file, but it's an overkill for true color render, so let's have reasonable cap.
* More precise «multiplier correction» and display of current rendering resolution (shamelessly taken from Nugget Doom! 🧡)
* Doom: optimized status bar drawing. Could be much better, but even redrawing every game tic (not every frame) gives huge FPS boost on 6x resolution. Should be useful for smaller resolutions as well.
* Hopefully better fail-safe return in case of active post rendering hook. Now it's able to survive stress-test like drawing extreme scene while holding button for resolution changing in uncapped fps.