### PR TITLE
Optimize status bar background drawing

### DIFF
--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -815,10 +815,6 @@ boolean AM_Responder (event_t *ev)
         if (ev->type == ev_keydown && ev->data1 == key_map_toggle)
         {
             AM_Start ();
-            if (automapactive && !automap_overlay)
-            {
-                st_fullupdate = true;
-            }
             rc = true;
         }
     }
@@ -953,10 +949,14 @@ boolean AM_Responder (event_t *ev)
         {
             // [JN] Automap overlay mode.
             automap_overlay = !automap_overlay;
-            CT_SetMessage(plr, DEH_String(automap_overlay ?
-                          ID_AUTOMAPOVERLAY_ON : ID_AUTOMAPOVERLAY_OFF), false, NULL);
-            if (automapactive && !automap_overlay)
+            if (automap_overlay)
             {
+                CT_SetMessage(plr, DEH_String(ID_AUTOMAPOVERLAY_ON), false, NULL);
+            }
+            else
+            {
+                CT_SetMessage(plr, DEH_String(ID_AUTOMAPOVERLAY_OFF), false, NULL);
+                // [JN] Redraw status bar background.
                 st_fullupdate = true;
             }
         }

--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -800,6 +800,11 @@ boolean AM_Responder (event_t *ev)
         if (!automapactive)
         {
             AM_Start ();
+            if (!automap_overlay)
+            {
+                // [JN] Redraw status bar background.
+                st_fullupdate = true;
+            }
         }
         else
         {
@@ -815,6 +820,11 @@ boolean AM_Responder (event_t *ev)
         if (ev->type == ev_keydown && ev->data1 == key_map_toggle)
         {
             AM_Start ();
+            if (!automap_overlay)
+            {
+                // [JN] Redraw status bar background.
+                st_fullupdate = true;
+            }
             rc = true;
         }
     }

--- a/src/doom/am_map.c
+++ b/src/doom/am_map.c
@@ -815,6 +815,10 @@ boolean AM_Responder (event_t *ev)
         if (ev->type == ev_keydown && ev->data1 == key_map_toggle)
         {
             AM_Start ();
+            if (automapactive && !automap_overlay)
+            {
+                st_fullupdate = true;
+            }
             rc = true;
         }
     }
@@ -951,6 +955,10 @@ boolean AM_Responder (event_t *ev)
             automap_overlay = !automap_overlay;
             CT_SetMessage(plr, DEH_String(automap_overlay ?
                           ID_AUTOMAPOVERLAY_ON : ID_AUTOMAPOVERLAY_OFF), false, NULL);
+            if (automapactive && !automap_overlay)
+            {
+                st_fullupdate = true;
+            }
         }
         else
         {

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -373,10 +373,9 @@ static void D_Display (void)
         {
             // [JN] Only forcefully update/redraw on...
             const boolean st_forceredraw = 
-                             (oldgametic < gametic             // Every game tic
-                          ||  dp_screen_size > 10              // Crispy HUD (no solid status bar background)
-                          ||  setsizeneeded                    // Screen size changing
-                          || (menuactive && dp_menu_shading)); // Active menu and background shading effect
+                             (oldgametic < gametic  // Every game tic
+                          ||  dp_screen_size > 10   // Crispy HUD (no solid status bar background)
+                          ||  setsizeneeded);       // Screen size changing
 
             ST_Drawer(st_forceredraw);
         }

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -537,6 +537,7 @@ void D_DoomLoop (void)
     I_RegisterWindowIcon(doom_data, doom_w, doom_h);
     I_InitGraphics();
     V_EnableLoadingDisk();
+    ST_InitElementsBackground(); // [JN] re-calculate status bar elements background buffers
 
     TryRunTics();
 

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -537,7 +537,8 @@ void D_DoomLoop (void)
     I_RegisterWindowIcon(doom_data, doom_w, doom_h);
     I_InitGraphics();
     V_EnableLoadingDisk();
-    ST_InitElementsBackground(); // [JN] re-calculate status bar elements background buffers
+    // [JN] Calculate status bar elements background buffers.
+    ST_InitElementsBackground();
 
     TryRunTics();
 

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1491,7 +1491,7 @@ void G_PlayerFinishLevel (int player)
     // [crispy] reset additional player properties
     p->lookdir = p->oldlookdir = p->centering = 0;
     st_palette = 0;
-    // [JN] Refresh the status bar.
+    // [JN] Redraw status bar background.
     if (p == &players[consoleplayer])
     {
         st_fullupdate = true;
@@ -1545,7 +1545,7 @@ void G_PlayerReborn (int player)
     for (i=0 ; i<NUMAMMO ; i++) 
 	p->maxammo[i] = maxammo[i]; 
 		 
-    // [JN] Refresh the status bar.
+    // [JN] Redraw status bar background.
     if (p == &players[consoleplayer])
     {
         st_fullupdate = true;

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1491,6 +1491,11 @@ void G_PlayerFinishLevel (int player)
     // [crispy] reset additional player properties
     p->lookdir = p->oldlookdir = p->centering = 0;
     st_palette = 0;
+    // [JN] Refresh the status bar.
+    if (p == &players[consoleplayer])
+    {
+        st_fullupdate = true;
+    }
     // [JN] Return controls to the player.
     crl_spectating = 0;
 } 
@@ -1540,6 +1545,11 @@ void G_PlayerReborn (int player)
     for (i=0 ; i<NUMAMMO ; i++) 
 	p->maxammo[i] = maxammo[i]; 
 		 
+    // [JN] Refresh the status bar.
+    if (p == &players[consoleplayer])
+    {
+        st_fullupdate = true;
+    }
 }
 
 //

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -4771,7 +4771,7 @@ static void M_DrawMainMenu(void)
 {
     M_ShadeBackground();
 
-    // [JN] Refresh the status bar.
+    // [JN] Always redraw status bar background.
     st_fullupdate = true;
 
     V_DrawPatch(94, 2, W_CacheLumpName(DEH_String("M_DOOM"), PU_CACHE));
@@ -4787,7 +4787,7 @@ static void M_DrawNewGame(void)
 {
     M_ShadeBackground();
 
-    // [JN] Refresh the status bar.
+    // [JN] Always redraw status bar background.
     st_fullupdate = true;
 
     V_DrawShadowedPatchOptional(96, 14, 0, W_CacheLumpName(DEH_String("M_NEWG"), PU_CACHE));
@@ -4820,7 +4820,7 @@ static void M_DrawEpisode(void)
 {
     M_ShadeBackground();
 
-    // [JN] Refresh the status bar.
+    // [JN] Always redraw status bar background.
     st_fullupdate = true;
 
     V_DrawShadowedPatchOptional(54, 38, 0, W_CacheLumpName(DEH_String("M_EPISOD"), PU_CACHE));
@@ -5921,7 +5921,6 @@ boolean M_Responder (event_t* ev)
             st_fullupdate = true;
         }
 #endif
-        
         return true;
     }
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1599,6 +1599,7 @@ static void M_ID_Gamma (int choice)
     R_InitColormaps();
     R_FillBackScreen();
 #endif
+    st_fullupdate = true;
 }
 
 static void M_ID_FOV (int choice)
@@ -3837,6 +3838,9 @@ static void M_Choose_ID_Level_1 (int choice)
 static void M_Draw_ID_Level_1 (void)
 {
     char str[32];
+
+    st_fullupdate = true;
+
     M_FillBackground();
     
     M_WriteTextCentered(16, "LEVEL SELECT", cr[CR_YELLOW]);
@@ -4052,6 +4056,8 @@ static void M_Choose_ID_Level_2 (int choice)
 static void M_Draw_ID_Level_2 (void)
 {
     char str[32];
+
+    st_fullupdate = true;
 
     M_FillBackground();
     
@@ -4668,6 +4674,7 @@ static void M_QuickLoad(void)
 static void M_DrawReadThis1(void)
 {
     V_DrawPatchFullScreen(W_CacheLumpName(DEH_String("HELP2"), PU_CACHE), false);
+    st_fullupdate = true;
 }
 
 
@@ -4681,11 +4688,13 @@ static void M_DrawReadThis2(void)
     // gameversion == exe_doom_1_9 and gamemode == registered
 
     V_DrawPatchFullScreen(W_CacheLumpName(DEH_String("HELP1"), PU_CACHE), false);
+    st_fullupdate = true;
 }
 
 static void M_DrawReadThisCommercial(void)
 {
     V_DrawPatchFullScreen(W_CacheLumpName(DEH_String("HELP"), PU_CACHE), false);
+    st_fullupdate = true;
 }
 
 
@@ -5893,6 +5902,7 @@ boolean M_Responder (event_t* ev)
             R_FillBackScreen();
         }
 #endif
+        st_fullupdate = true;
         return true;
     }
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -878,6 +878,8 @@ static void M_ShadeBackground (void)
             I_VideoBuffer[y] = I_BlendDark(I_VideoBuffer[y], I_ShadeFactor[dp_menu_shading]);
 #endif
         }
+        
+        st_fullupdate = true;
     }
 }
 
@@ -1598,8 +1600,8 @@ static void M_ID_Gamma (int choice)
     I_SetPalette (st_palette);
     R_InitColormaps();
     R_FillBackScreen();
-#endif
     st_fullupdate = true;
+#endif
 }
 
 static void M_ID_FOV (int choice)
@@ -4673,8 +4675,9 @@ static void M_QuickLoad(void)
 //
 static void M_DrawReadThis1(void)
 {
-    V_DrawPatchFullScreen(W_CacheLumpName(DEH_String("HELP2"), PU_CACHE), false);
     st_fullupdate = true;
+
+    V_DrawPatchFullScreen(W_CacheLumpName(DEH_String("HELP2"), PU_CACHE), false);
 }
 
 
@@ -4684,17 +4687,19 @@ static void M_DrawReadThis1(void)
 //
 static void M_DrawReadThis2(void)
 {
+    st_fullupdate = true;
+
     // We only ever draw the second page if this is 
     // gameversion == exe_doom_1_9 and gamemode == registered
 
     V_DrawPatchFullScreen(W_CacheLumpName(DEH_String("HELP1"), PU_CACHE), false);
-    st_fullupdate = true;
 }
 
 static void M_DrawReadThisCommercial(void)
 {
-    V_DrawPatchFullScreen(W_CacheLumpName(DEH_String("HELP"), PU_CACHE), false);
     st_fullupdate = true;
+
+    V_DrawPatchFullScreen(W_CacheLumpName(DEH_String("HELP"), PU_CACHE), false);
 }
 
 
@@ -4762,6 +4767,9 @@ static void M_DrawMainMenu(void)
 {
     M_ShadeBackground();
 
+    // [JN] Refresh the status bar.
+    st_fullupdate = true;
+
     V_DrawPatch(94, 2, W_CacheLumpName(DEH_String("M_DOOM"), PU_CACHE));
 }
 
@@ -4774,6 +4782,9 @@ static void M_DrawMainMenu(void)
 static void M_DrawNewGame(void)
 {
     M_ShadeBackground();
+
+    // [JN] Refresh the status bar.
+    st_fullupdate = true;
 
     V_DrawShadowedPatchOptional(96, 14, 0, W_CacheLumpName(DEH_String("M_NEWG"), PU_CACHE));
     V_DrawShadowedPatchOptional(54, 38, 0, W_CacheLumpName(DEH_String("M_SKILL"), PU_CACHE));
@@ -4804,6 +4815,9 @@ static int epi;
 static void M_DrawEpisode(void)
 {
     M_ShadeBackground();
+
+    // [JN] Refresh the status bar.
+    st_fullupdate = true;
 
     V_DrawShadowedPatchOptional(54, 38, 0, W_CacheLumpName(DEH_String("M_EPISOD"), PU_CACHE));
 }
@@ -5900,9 +5914,10 @@ boolean M_Responder (event_t* ev)
             I_SetPalette (st_palette);
             R_InitColormaps();
             R_FillBackScreen();
+            st_fullupdate = true;
         }
 #endif
-        st_fullupdate = true;
+        
         return true;
     }
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1299,6 +1299,8 @@ static void M_ID_RenderingResHook (void)
     R_FillBackScreen();
     // [crispy] re-calculate disk icon coordinates
     V_EnableLoadingDisk();
+    // [JN] re-calculate status bar elements background buffers
+    ST_InitElementsBackground();
     // [crispy] re-calculate automap coordinates
     AM_LevelInit(true);
     if (automapactive)
@@ -1323,6 +1325,8 @@ static void M_ID_WidescreenHook (void)
     R_FillBackScreen();
     // [crispy] re-calculate disk icon coordinates
     V_EnableLoadingDisk();
+    // [JN] re-calculate status bar elements background buffers
+    ST_InitElementsBackground();
     // [crispy] re-calculate automap coordinates
     AM_LevelInit(true);
     if (automapactive)

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -904,7 +904,7 @@ void R_ExecuteSetViewSize (void)
 
     pspr_interp = false; // [crispy] interpolate weapon bobbing
     
-    st_fullupdate = true; // [JN] Redraw status bar.
+    st_fullupdate = true; // [JN] Redraw status bar background.
 }
 
 

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -903,6 +903,8 @@ void R_ExecuteSetViewSize (void)
     flipviewwidth = flipscreenwidth + (gp_flip_levels ? (SCREENWIDTH - scaledviewwidth) : 0);
 
     pspr_interp = false; // [crispy] interpolate weapon bobbing
+    
+    st_fullupdate = true; // [JN] Redraw status bar.
 }
 
 

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -120,6 +120,16 @@ static int st_faceindex = 1;  // current face index, used by w_faces
 static int st_randomnumber; // a random number per tick
 static int faceindex; // [crispy] fix status bar face hysteresis
 
+// [JN] Variables for buffered status bar drawing via V_CopyRect.
+static int ammo_x, ammo_size_x, ammo_size_y, ammo_y_start, ammo_y_end;
+static int hlth_x, hlth_size_x, hlth_size_y, hlth_y_start, hlth_y_end;
+static int face_x, face_size_x, face_size_y, face_y_start, face_y_end;
+static int armr_x, armr_size_x, armr_size_y, armr_y_start, armr_y_end;
+static int keys_x, keys_size_x, keys_size_y, keys_y_start, keys_y_end;
+static int amoc_x, amoc_size_x, amoc_size_y, amoc_y_start, amoc_y_end;
+static int amom_x, amom_size_x, amom_size_y, amom_y_start, amom_y_end;
+static int disk_x, disk_size_x, disk_size_y, disk_y_start, disk_y_end;
+
 cheatseq_t cheat_wait = CHEAT("id", 0);
 cheatseq_t cheat_mus = CHEAT("idmus", 2);
 cheatseq_t cheat_god = CHEAT("iddqd", 0);
@@ -1337,60 +1347,44 @@ static void ST_DrawWeaponNumberFunc (const int val, const int x, const int y, co
 static void ST_UpdateElementsBackground (void)
 {
     // Ammo
-    V_CopyRect(AMMO_X, AMMO_Y_START, 
-               st_backing_screen, 
-               45 * vid_resolution,
-               20 * vid_resolution,
-               AMMO_X, AMMO_Y_END);
+    V_CopyRect(ammo_x, ammo_y_start, st_backing_screen,
+               ammo_size_x, ammo_size_y,
+               ammo_x, ammo_y_end);
 
     // Health
-    V_CopyRect(HEALTH_X, HEALTH_Y_START,
-               st_backing_screen, 
-               55 * vid_resolution,
-               20 * vid_resolution,
-               HEALTH_X, HEALTH_Y_END);
+    V_CopyRect(hlth_x, hlth_y_start, st_backing_screen,
+               hlth_size_x, hlth_size_y,
+               hlth_x, hlth_y_end);
 
     // Player face
-    V_CopyRect(FACE_X, FACE_Y_START,
-               st_backing_screen, 
-               37 * vid_resolution,
-               32 * vid_resolution,
-               FACE_X, FACE_Y_END);
+    V_CopyRect(face_x, face_y_start, st_backing_screen,
+               face_size_x, face_size_y,
+               face_x, face_y_end);
 
     // Armor
-    V_CopyRect(ARMOR_X, ARMOR_Y_START,
-               st_backing_screen, 
-               56 * vid_resolution,
-               20 * vid_resolution,
-               ARMOR_X, ARMOR_Y_END);
+    V_CopyRect(armr_x, armr_y_start, st_backing_screen,
+               armr_size_x, armr_size_y,
+               armr_x, armr_y_end);
 
     // Keys
-    V_CopyRect(KEYS_X, KEYS_Y_START,
-               st_backing_screen, 
-               13 * vid_resolution,
-               32 * vid_resolution,
-               KEYS_X, KEYS_Y_END);
+    V_CopyRect(keys_x, keys_y_start, st_backing_screen,
+               keys_size_x, keys_size_y,
+               keys_x, keys_y_end);
 
     // Ammo (current)
-    V_CopyRect(AMMO_C_X, AMMO_C_Y_START,
-               st_backing_screen, 
-               16 * vid_resolution,
-               24 * vid_resolution,
-               AMMO_C_X, AMMO_C_Y_END);
+    V_CopyRect(amoc_x, amoc_y_start, st_backing_screen,
+               amoc_size_x, amoc_size_y,
+               amoc_x, amoc_y_end);
 
     // Ammo (max)
-    V_CopyRect(AMMO_M_X, AMMO_M_Y_START,
-               st_backing_screen, 
-               16 * vid_resolution,
-               24 * vid_resolution,
-               AMMO_M_X, AMMO_M_Y_END);
+    V_CopyRect(amom_x, amom_y_start, st_backing_screen,
+               amom_size_x, amom_size_y,
+               amom_x, amom_y_end);
 
     // Disk icon
-    V_CopyRect(DISK_X, DISK_Y_START,
-               st_backing_screen, 
-               16 * vid_resolution,
-               16 * vid_resolution,
-               DISK_X, DISK_Y_END);
+    V_CopyRect(disk_x, disk_y_start, st_backing_screen,
+               disk_size_x, disk_size_y,
+               disk_x, disk_y_end);
 }
 
 // -----------------------------------------------------------------------------
@@ -1770,4 +1764,69 @@ void ST_Init (void)
     ST_loadData();
     st_backing_screen = (pixel_t *) Z_Malloc(MAXWIDTH * (ST_HEIGHT * MAXHIRES)
                       * sizeof(*st_backing_screen), PU_STATIC, 0);
+}
+
+// -----------------------------------------------------------------------------
+// ST_InitElementsBackground
+// [JN] Preallocate rectangle sizes for status bar buffered drawing 
+//      to avoid some extra multiplying calculations while drawing.
+// -----------------------------------------------------------------------------
+
+void ST_InitElementsBackground (void)
+{
+    // Ammo
+    ammo_x = WIDESCREENDELTA * vid_resolution;
+    ammo_size_x = 45 * vid_resolution;
+    ammo_size_y = 20 * vid_resolution;
+    ammo_y_start = 2 * vid_resolution;
+    ammo_y_end = 170 * vid_resolution;
+
+    // Health
+    hlth_x = (49 + WIDESCREENDELTA) * vid_resolution;
+    hlth_size_x = 55 * vid_resolution;
+    hlth_size_y = 20 * vid_resolution;
+    hlth_y_start = 2 * vid_resolution;
+    hlth_y_end = 170 * vid_resolution;
+
+    // Player face background
+    face_x = (142 + WIDESCREENDELTA) * vid_resolution;
+    face_size_x = 37 * vid_resolution;
+    face_size_y = 32 * vid_resolution;
+    face_y_start = 0;
+    face_y_end = 168 * vid_resolution;
+
+    // Armor
+    armr_x = (179 + WIDESCREENDELTA) * vid_resolution;
+    armr_size_x = 56 * vid_resolution;
+    armr_size_y = 20 * vid_resolution;
+    armr_y_start = 2 * vid_resolution;
+    armr_y_end = 170 * vid_resolution;
+
+    // Keys
+    keys_x = (236 + WIDESCREENDELTA) * vid_resolution;
+    keys_size_x = 13 * vid_resolution;
+    keys_size_y = 32 * vid_resolution;
+    keys_y_start = 0;
+    keys_y_end = 168 * vid_resolution;
+
+    // Ammo (current)
+    amoc_x = (272 + WIDESCREENDELTA) * vid_resolution;
+    amoc_size_x = 16 * vid_resolution;
+    amoc_size_y = 24 * vid_resolution;
+    amoc_y_start = 5 * vid_resolution;
+    amoc_y_end = 173 * vid_resolution;
+
+    // Ammo (max)
+    amom_x = (298 + WIDESCREENDELTA) * vid_resolution;
+    amom_size_x = 16 * vid_resolution;
+    amom_size_y = 24 * vid_resolution;
+    amom_y_start = 5 * vid_resolution;
+    amom_y_end = 173 * vid_resolution;
+
+    // Disk icon
+    disk_x = (304 + WIDESCREENDELTA * 2) * vid_resolution;
+    disk_size_x = 16 * vid_resolution;
+    disk_size_y = 16 * vid_resolution;
+    disk_y_start = 17 * vid_resolution;
+    disk_y_end = 185 * vid_resolution;
 }

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -120,6 +120,9 @@ static int st_faceindex = 1;  // current face index, used by w_faces
 static int st_randomnumber; // a random number per tick
 static int faceindex; // [crispy] fix status bar face hysteresis
 
+// [JN] Condition to redraw status bar background. 
+boolean st_fullupdate = true;
+
 // [JN] Variables for buffered status bar drawing via V_CopyRect.
 static int ammo_x, ammo_size_x, ammo_size_y, ammo_y_start, ammo_y_end;
 static int hlth_x, hlth_size_x, hlth_size_y, hlth_y_start, hlth_y_end;
@@ -1359,8 +1362,6 @@ static void ST_UpdateElementsBackground (void)
 // ST_Drawer
 // [JN] Main drawing function, totally rewritten.
 // -----------------------------------------------------------------------------
-
-boolean st_fullupdate = true;
 
 void ST_Drawer (boolean force)
 {

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -123,15 +123,9 @@ static int faceindex; // [crispy] fix status bar face hysteresis
 // [JN] Condition to redraw status bar background. 
 boolean st_fullupdate = true;
 
-// [JN] Variables for buffered status bar drawing via V_CopyRect.
-static int ammo_x, ammo_size_x, ammo_size_y, ammo_y_start, ammo_y_end;
-static int hlth_x, hlth_size_x, hlth_size_y, hlth_y_start, hlth_y_end;
-static int face_x, face_size_x, face_size_y, face_y_start, face_y_end;
-static int armr_x, armr_size_x, armr_size_y, armr_y_start, armr_y_end;
-static int keys_x, keys_size_x, keys_size_y, keys_y_start, keys_y_end;
-static int amoc_x, amoc_size_x, amoc_size_y, amoc_y_start, amoc_y_end;
-static int amom_x, amom_size_x, amom_size_y, amom_y_start, amom_y_end;
-static int disk_x, disk_size_x, disk_size_y, disk_y_start, disk_y_end;
+// [JN] Arrays for holding buffered background of status bar elements.
+static int ammo_bg[5], hlth_bg[5], face_bg[5], armr_bg[5];
+static int keys_bg[5], amoc_bg[5], amom_bg[5], disk_bg[5];
 
 cheatseq_t cheat_wait = CHEAT("id", 0);
 cheatseq_t cheat_mus = CHEAT("idmus", 2);
@@ -1318,44 +1312,44 @@ static void ST_DrawWeaponNumberFunc (const int val, const int x, const int y, co
 static void ST_UpdateElementsBackground (void)
 {
     // Ammo
-    V_CopyRect(ammo_x, ammo_y_start, st_backing_screen,
-               ammo_size_x, ammo_size_y,
-               ammo_x, ammo_y_end);
+    V_CopyRect(ammo_bg[0], ammo_bg[1], st_backing_screen,
+               ammo_bg[2], ammo_bg[3],
+               ammo_bg[0], ammo_bg[4]);
 
     // Health
-    V_CopyRect(hlth_x, hlth_y_start, st_backing_screen,
-               hlth_size_x, hlth_size_y,
-               hlth_x, hlth_y_end);
+    V_CopyRect(hlth_bg[0], hlth_bg[1], st_backing_screen,
+               hlth_bg[2], hlth_bg[3],
+               hlth_bg[0], hlth_bg[4]);
 
     // Player face
-    V_CopyRect(face_x, face_y_start, st_backing_screen,
-               face_size_x, face_size_y,
-               face_x, face_y_end);
+    V_CopyRect(face_bg[0], face_bg[1], st_backing_screen,
+               face_bg[2], face_bg[3],
+               face_bg[0], face_bg[4]);
 
     // Armor
-    V_CopyRect(armr_x, armr_y_start, st_backing_screen,
-               armr_size_x, armr_size_y,
-               armr_x, armr_y_end);
+    V_CopyRect(armr_bg[0], armr_bg[1], st_backing_screen,
+               armr_bg[2], armr_bg[3],
+               armr_bg[0], armr_bg[4]);
 
     // Keys
-    V_CopyRect(keys_x, keys_y_start, st_backing_screen,
-               keys_size_x, keys_size_y,
-               keys_x, keys_y_end);
+    V_CopyRect(keys_bg[0], keys_bg[1], st_backing_screen,
+               keys_bg[2], keys_bg[3],
+               keys_bg[0], keys_bg[4]);
 
     // Ammo (current)
-    V_CopyRect(amoc_x, amoc_y_start, st_backing_screen,
-               amoc_size_x, amoc_size_y,
-               amoc_x, amoc_y_end);
+    V_CopyRect(amoc_bg[0], amoc_bg[1], st_backing_screen,
+               amoc_bg[2], amoc_bg[3],
+               amoc_bg[0], amoc_bg[4]);
 
     // Ammo (max)
-    V_CopyRect(amom_x, amom_y_start, st_backing_screen,
-               amom_size_x, amom_size_y,
-               amom_x, amom_y_end);
+    V_CopyRect(amom_bg[0], amom_bg[1], st_backing_screen,
+               amom_bg[2], amom_bg[3],
+               amom_bg[0], amom_bg[4]);
 
     // Disk icon
-    V_CopyRect(disk_x, disk_y_start, st_backing_screen,
-               disk_size_x, disk_size_y,
-               disk_x, disk_y_end);
+    V_CopyRect(disk_bg[0], disk_bg[1], st_backing_screen,
+               disk_bg[2], disk_bg[3],
+               disk_bg[0], disk_bg[4]);
 }
 
 // -----------------------------------------------------------------------------
@@ -1744,58 +1738,58 @@ void ST_Init (void)
 void ST_InitElementsBackground (void)
 {
     // Ammo
-    ammo_x = WIDESCREENDELTA * vid_resolution;
-    ammo_size_x = 45 * vid_resolution;
-    ammo_size_y = 20 * vid_resolution;
-    ammo_y_start = 2 * vid_resolution;
-    ammo_y_end = 170 * vid_resolution;
+    ammo_bg[0] = WIDESCREENDELTA * vid_resolution;
+    ammo_bg[1] = 2 * vid_resolution;
+    ammo_bg[2] = 45 * vid_resolution;
+    ammo_bg[3] = 20 * vid_resolution;
+    ammo_bg[4] = 170 * vid_resolution;
 
     // Health
-    hlth_x = (49 + WIDESCREENDELTA) * vid_resolution;
-    hlth_size_x = 55 * vid_resolution;
-    hlth_size_y = 20 * vid_resolution;
-    hlth_y_start = 2 * vid_resolution;
-    hlth_y_end = 170 * vid_resolution;
+    hlth_bg[0] = (49 + WIDESCREENDELTA) * vid_resolution;
+    hlth_bg[1] = 2 * vid_resolution;
+    hlth_bg[2] = 55 * vid_resolution;
+    hlth_bg[3] = 20 * vid_resolution;
+    hlth_bg[4] = 170 * vid_resolution;
 
     // Player face background
-    face_x = (142 + WIDESCREENDELTA) * vid_resolution;
-    face_size_x = 37 * vid_resolution;
-    face_size_y = 32 * vid_resolution;
-    face_y_start = 0;
-    face_y_end = 168 * vid_resolution;
+    face_bg[0] = (142 + WIDESCREENDELTA) * vid_resolution;
+    face_bg[1] = 0;
+    face_bg[2] = 37 * vid_resolution;
+    face_bg[3] = 32 * vid_resolution;
+    face_bg[4] = 168 * vid_resolution;
 
     // Armor
-    armr_x = (179 + WIDESCREENDELTA) * vid_resolution;
-    armr_size_x = 56 * vid_resolution;
-    armr_size_y = 20 * vid_resolution;
-    armr_y_start = 2 * vid_resolution;
-    armr_y_end = 170 * vid_resolution;
+    armr_bg[0] = (179 + WIDESCREENDELTA) * vid_resolution;
+    armr_bg[1] = 2 * vid_resolution;
+    armr_bg[2] = 56 * vid_resolution;
+    armr_bg[3] = 20 * vid_resolution;
+    armr_bg[4] = 170 * vid_resolution;    
 
     // Keys
-    keys_x = (236 + WIDESCREENDELTA) * vid_resolution;
-    keys_size_x = 13 * vid_resolution;
-    keys_size_y = 32 * vid_resolution;
-    keys_y_start = 0;
-    keys_y_end = 168 * vid_resolution;
+    keys_bg[0] = (236 + WIDESCREENDELTA) * vid_resolution;
+    keys_bg[1] = 0;
+    keys_bg[2] = 13 * vid_resolution;
+    keys_bg[3] = 32 * vid_resolution;
+    keys_bg[4] = 168 * vid_resolution;
 
     // Ammo (current)
-    amoc_x = (272 + WIDESCREENDELTA) * vid_resolution;
-    amoc_size_x = 16 * vid_resolution;
-    amoc_size_y = 24 * vid_resolution;
-    amoc_y_start = 5 * vid_resolution;
-    amoc_y_end = 173 * vid_resolution;
+    amoc_bg[0] = (272 + WIDESCREENDELTA) * vid_resolution;
+    amoc_bg[1] = 5 * vid_resolution;
+    amoc_bg[2] = 16 * vid_resolution;
+    amoc_bg[3] = 24 * vid_resolution;
+    amoc_bg[4] = 173 * vid_resolution;
 
     // Ammo (max)
-    amom_x = (298 + WIDESCREENDELTA) * vid_resolution;
-    amom_size_x = 16 * vid_resolution;
-    amom_size_y = 24 * vid_resolution;
-    amom_y_start = 5 * vid_resolution;
-    amom_y_end = 173 * vid_resolution;
+    amom_bg[0] = (298 + WIDESCREENDELTA) * vid_resolution;
+    amom_bg[1] = 5 * vid_resolution;
+    amom_bg[2] = 16 * vid_resolution;
+    amom_bg[3] = 24 * vid_resolution;
+    amom_bg[4] = 173 * vid_resolution;
 
     // Disk icon
-    disk_x = (304 + WIDESCREENDELTA * 2) * vid_resolution;
-    disk_size_x = 16 * vid_resolution;
-    disk_size_y = 16 * vid_resolution;
-    disk_y_start = 17 * vid_resolution;
-    disk_y_end = 185 * vid_resolution;
+    disk_bg[0] = (304 + WIDESCREENDELTA * 2) * vid_resolution;
+    disk_bg[1] = 17 * vid_resolution;
+    disk_bg[2] = 16 * vid_resolution;
+    disk_bg[3] = 16 * vid_resolution;
+    disk_bg[4] = 185 * vid_resolution;
 }

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -1312,38 +1312,6 @@ static void ST_DrawWeaponNumberFunc (const int val, const int x, const int y, co
 //      This is notably faster than re-drawing entire background.
 // -----------------------------------------------------------------------------
 
-#define AMMO_X          (WIDESCREENDELTA * vid_resolution)
-#define AMMO_Y_START    (2 * vid_resolution)
-#define AMMO_Y_END      (170 * vid_resolution)
-
-#define HEALTH_X        ((49 + WIDESCREENDELTA) * vid_resolution)
-#define HEALTH_Y_START  (2 * vid_resolution)
-#define HEALTH_Y_END    AMMO_Y_END
-
-#define FACE_X          ((142 + WIDESCREENDELTA) * vid_resolution)
-#define FACE_Y_START    (0)
-#define FACE_Y_END      (168 * vid_resolution)
-
-#define ARMOR_X         ((179 + WIDESCREENDELTA) * vid_resolution)
-#define ARMOR_Y_START   (2 * vid_resolution)
-#define ARMOR_Y_END     AMMO_Y_END
-
-#define KEYS_X          ((236 + WIDESCREENDELTA) * vid_resolution)
-#define KEYS_Y_START    (0)
-#define KEYS_Y_END      (168 * vid_resolution)
-
-#define AMMO_C_X        ((272 + WIDESCREENDELTA) * vid_resolution)
-#define AMMO_C_Y_START  (5 * vid_resolution)
-#define AMMO_C_Y_END    (173 * vid_resolution)
-
-#define AMMO_M_X        ((298 + WIDESCREENDELTA) * vid_resolution)
-#define AMMO_M_Y_START  AMMO_C_Y_START
-#define AMMO_M_Y_END    AMMO_C_Y_END
-
-#define DISK_X          ((304 + WIDESCREENDELTA * 2) * vid_resolution)
-#define DISK_Y_START    (17 * vid_resolution)
-#define DISK_Y_END      (185 * vid_resolution)
-
 static void ST_UpdateElementsBackground (void)
 {
     // Ammo

--- a/src/doom/st_bar.h
+++ b/src/doom/st_bar.h
@@ -52,7 +52,7 @@ void ST_Start (void);
 // Called by startup code.
 void ST_Init (void);
 
-// [JN] Preallocate rectangle sizes for status bar buffered drawing.
+// [JN] Allocate rectangle sizes for status bar buffered drawing.
 extern void ST_InitElementsBackground (void);
 
 

--- a/src/doom/st_bar.h
+++ b/src/doom/st_bar.h
@@ -52,6 +52,9 @@ void ST_Start (void);
 // Called by startup code.
 void ST_Init (void);
 
+// [JN] Preallocate rectangle sizes for status bar buffered drawing.
+extern void ST_InitElementsBackground (void);
+
 
 extern cheatseq_t cheat_mus;
 extern cheatseq_t cheat_god;

--- a/src/doom/st_bar.h
+++ b/src/doom/st_bar.h
@@ -65,5 +65,6 @@ extern cheatseq_t cheat_clev;
 extern cheatseq_t cheat_mypos;
 
 extern int st_palette;
+extern boolean st_fullupdate;
 
 #endif


### PR DESCRIPTION
This adds back `V_CopyRect` function for drawing background beneath status bar elements. Practically, this costs nothing comparing to (re-)drawing status bar every game/frame tic. This approach inspired by both Doom and Heretic games.