### PR TITLE
Heretic: improvements for demo recording/playback

### DIFF
--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -988,6 +988,9 @@ void D_DoomMain(void)
         startepisode = myargv[p + 1][0] - '0';
         startmap = myargv[p + 2][0] - '0';
         autostart = true;
+
+        // [crispy] if used with -playdemo, fast-forward demo up to the desired map
+        demowarp = startmap;
     }
 
 //
@@ -1374,6 +1377,9 @@ void D_DoomMain(void)
         G_DeferedPlayDemo(demolumpname);
         D_DoomLoop();           // Never returns
     }
+
+    // [crispy] we don't play a demo, so don't skip maps
+    demowarp = 0;
 
     p = M_CheckParmWithArgs("-timedemo", 1);
     if (p)

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1225,7 +1225,8 @@ void D_DoomMain(void)
     // after either level exit or player respawn.
     //
 
-    demoextend = M_ParmExists("-demoextend");
+    demoextend = (!M_ParmExists("-nodemoextend"));
+    //[crispy] make demoextend the default
 
     if (W_CheckNumForName(DEH_String("E2M1")) == -1)
     {

--- a/src/heretic/doomdef.h
+++ b/src/heretic/doomdef.h
@@ -729,6 +729,12 @@ void G_DeferedInitNew(skill_t skill, int episode, int map);
 extern boolean G_DoSelectiveGame (int choice);
 
 void G_DeferedPlayDemo(const char *demo);
+void G_DoPlayDemo(void);
+
+extern boolean netdemo;
+
+extern boolean demo_gotonextlvl;
+void G_DemoGoToNextLevel (boolean start);
 
 void G_LoadGame(char *name);
 // can be called by the startup code or M_Responder

--- a/src/heretic/doomdef.h
+++ b/src/heretic/doomdef.h
@@ -762,7 +762,7 @@ extern int savepage;
 #define SAVEPAGE_MAX 7
 
 void G_RecordDemo(skill_t skill, int numplayers, int episode, int map,
-                  char *name);
+                  const char *name);
 // only called by startup code
 
 void G_PlayDemo(char *name);

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -104,7 +104,7 @@ boolean sendsave;               // send a save event next tic
 boolean usergame;               // ok to save / end game
 
 boolean timingdemo;             // if true, exit with report on completion
-boolean nodrawers;              // for comparative timing purposes 
+boolean nodrawers = false; // [crispy] for the demowarp feature
 int starttime;                  // for comparative timing purposes
 
 boolean viewactive;
@@ -2213,8 +2213,6 @@ void G_InitNew(skill_t skill, int episode, int map)
     demorecording = false;
     demoplayback = false;
     netdemo = false;
-    // [crispy] reset game speed after demo fast-forward
-    singletics = false;
     // [JN] Reset automap scale. Fixes:
     // https://doomwiki.org/wiki/Automap_scale_preserved_after_warps_in_Heretic_and_Hexen
     automapactive = false; 
@@ -2626,6 +2624,13 @@ void G_DeferedPlayDemo(const char *name)
 {
     defdemoname = name;
     gameaction = ga_playdemo;
+
+    // [crispy] fast-forward demo up to the desired map
+    if (demowarp)
+    {
+        nodrawers = true;
+        singletics = true;
+    }
 }
 
 void G_DoPlayDemo(void)
@@ -2708,8 +2713,6 @@ void G_TimeDemo(char *name)
     skill_t skill;
     int episode, map, i;
     int lumpnum, lumplength; // [crispy]
-
-    nodrawers = M_CheckParm ("-nodraw");
 
     demobuffer = demo_p = W_CacheLumpName(name, PU_STATIC);
 

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -2999,15 +2999,12 @@ static void G_AddDemoFooter(void)
 {
     byte *data;
     size_t size;
-    char *project_string;
 
     MEMFILE *stream = mem_fopen_write();
 
     wadinfo_t header = { "PWAD" };
     header.numlumps = LONG(NUM_DEMO_FOOTER_LUMPS);
     mem_fwrite(&header, 1, sizeof(header), stream);
-
-    project_string = M_StringReplace(PACKAGE_STRING, "Doom", "Heretic");
 
     mem_fputs(PACKAGE_FULLNAME_HERETIC, stream);  // [JN] Use full port name.
     mem_fputs(DEMO_FOOTER_SEPARATOR, stream);
@@ -3019,7 +3016,7 @@ static void G_AddDemoFooter(void)
     mem_fwrite(&header, 1, sizeof(header), stream);
     mem_fseek(stream, 0, MEM_SEEK_END);
 
-    WriteFileInfo("PORTNAME", strlen(project_string), stream);
+    WriteFileInfo("PORTNAME", strlen(PACKAGE_STRING), stream);
     WriteFileInfo(NULL, strlen(DEMO_FOOTER_SEPARATOR), stream);
     WriteFileInfo("CMDLINE", size, stream);
     WriteFileInfo(NULL, strlen(DEMO_FOOTER_SEPARATOR), stream);
@@ -3034,7 +3031,6 @@ static void G_AddDemoFooter(void)
     memcpy(demo_p, data, size);
     demo_p += size;
 
-    free(project_string);
     mem_fclose(stream);
 }
 

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -64,7 +64,6 @@ void G_DoReborn(int playernum);
 
 void G_DoLoadLevel(void);
 void G_DoNewGame(void);
-void G_DoPlayDemo(void);
 void G_DoCompleted(void);
 void G_DoVictory(void);
 void G_DoWorldDone(void);
@@ -3128,3 +3127,21 @@ void G_DoSaveGame(void)
     free(filename);
 }
 
+//
+// G_DemoGoToNextLevel
+// [JN] Fast forward to next level while demo playback.
+//
+
+boolean demo_gotonextlvl;
+
+void G_DemoGoToNextLevel (boolean start)
+{
+    // Disable screen rendering while fast forwarding.
+    nodrawers = start;
+
+    // Switch to fast tics running mode if not in -timedemo.
+    if (!timingdemo)
+    {
+        singletics = start;
+    }
+} 

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -28,6 +28,7 @@
 #include "i_joystick.h"
 #include "i_timer.h"
 #include "i_system.h"
+#include "i_swap.h"
 #include "m_argv.h"
 #include "m_controls.h"
 #include "m_misc.h"
@@ -35,6 +36,10 @@
 #include "p_local.h"
 #include "s_sound.h"
 #include "v_video.h"
+
+#include "deh_main.h" // [crispy] for demo footer
+#include "memio.h"
+
 #include "am_map.h"
 #include "ct_chat.h"
 
@@ -124,7 +129,8 @@ boolean finalintermission; // [crispy] track intermission at end of episode
 
 int mouseSensitivity = 5;
 
-char demoname[32];
+char *demoname;
+static const char *orig_demoname = NULL; // [crispy] the name originally chosen for the demo, i.e. without "-00000"
 boolean demorecording;
 boolean longtics;               // specify high resolution turning in demos
 boolean lowres_turn;
@@ -1935,10 +1941,89 @@ void G_SecretExitLevel(void)
     gameaction = ga_completed;
 }
 
+// [crispy] format time for level statistics
+#define TIMESTRSIZE 16
+static void G_FormatLevelStatTime(char *str, int tics)
+{
+    int exitHours, exitMinutes;
+    float exitTime, exitSeconds;
+
+    exitTime = (float) tics / 35;
+    exitHours = exitTime / 3600;
+    exitTime -= exitHours * 3600;
+    exitMinutes = exitTime / 60;
+    exitTime -= exitMinutes * 60;
+    exitSeconds = exitTime;
+
+    if (exitHours)
+    {
+        M_snprintf(str, TIMESTRSIZE, "%d:%02d:%05.2f",
+                    exitHours, exitMinutes, exitSeconds);
+    }
+    else
+    {
+        M_snprintf(str, TIMESTRSIZE, "%01d:%05.2f", exitMinutes, exitSeconds);
+    }
+}
+
+// [crispy] Write level statistics upon exit
+static void G_WriteLevelStat(void)
+{
+    static FILE *fstream = NULL;
+
+    int i, playerKills = 0, playerItems = 0, playerSecrets = 0;
+
+    char levelTimeString[TIMESTRSIZE];
+    char totalTimeString[TIMESTRSIZE];
+    char *decimal;
+
+    if (fstream == NULL)
+    {
+        fstream = fopen("levelstat.txt", "w");
+
+        if (fstream == NULL)
+        {
+            fprintf(stderr, "G_WriteLevelStat: Unable to open levelstat.txt for writing!\n");
+            return;
+        }
+    }
+
+    G_FormatLevelStatTime(levelTimeString, leveltime);
+    G_FormatLevelStatTime(totalTimeString, totalleveltimes + leveltime);
+
+    // Total time ignores centiseconds
+    decimal = strchr(totalTimeString, '.');
+    if (decimal != NULL)
+    {
+        *decimal = '\0';
+    }
+
+    for (i = 0; i < MAXPLAYERS; i++)
+    {
+        if (playeringame[i])
+        {
+            playerKills += players[i].killcount;
+            playerItems += players[i].itemcount;
+            playerSecrets += players[i].secretcount;
+        }
+    }
+
+    fprintf(fstream, "E%dM%d%s - %s (%s)  K: %d/%d  I: %d/%d  S: %d/%d\n",
+            gameepisode, gamemap, (secretexit ? "s" : ""),
+            levelTimeString, totalTimeString, playerKills, totalkills, 
+            playerItems, totalitems, playerSecrets, totalsecret);
+}
+
 void G_DoCompleted(void)
 {
     int i;
     static int afterSecret[5] = { 7, 5, 5, 5, 4 };
+
+    // [crispy] Write level statistics upon exit
+    if (M_ParmExists("-levelstat"))
+    {
+        G_WriteLevelStat();
+    }
 
     gameaction = ga_nothing;
 
@@ -2149,6 +2234,14 @@ void G_DeferedInitNew(skill_t skill, int episode, int map)
     d_episode = episode;
     d_map = map;
     gameaction = ga_newgame;
+
+    // [crispy] if a new game is started during demo recording, start a new demo
+    if (demorecording)
+    {
+	G_CheckDemoStatus();
+	Z_Free(demoname);
+	G_RecordDemo(skill, 1, episode, map, orig_demoname);
+    }
 }
 
 void G_DoNewGame(void)
@@ -2372,8 +2465,6 @@ boolean G_DoSelectiveGame (int choice)
 
 // [crispy] demo progress bar and timer widget
 int defdemotics = 0, deftotaldemotics;
-// [crispy] moved here
-static const char *defdemoname;
 
 void G_ReadDemoTiccmd(ticcmd_t * cmd)
 {
@@ -2499,10 +2590,21 @@ void G_WriteDemoTiccmd(ticcmd_t * cmd)
 */
 
 void G_RecordDemo(skill_t skill, int numplayers, int episode, int map,
-                  char *name)
+                  const char *name)
 {
+    size_t demoname_size;
     int i;
     int maxsize;
+
+    // [crispy] demo file name suffix counter
+    static unsigned int j = 0;
+    FILE *fp = NULL;
+
+    // [crispy] the name originally chosen for the demo, i.e. without "-00000"
+    if (!orig_demoname)
+    {
+	orig_demoname = name;
+    }
 
     //!
     // @category demo
@@ -2520,16 +2622,25 @@ void G_RecordDemo(skill_t skill, int numplayers, int episode, int map,
     //!
     // @category demo
     //
-    // Smooth out low resolution turning when recording a demo.
+    // Don't smooth out low resolution turning when recording a demo.
     //
 
-    shortticfix = M_ParmExists("-shortticfix");
+    shortticfix = (!M_ParmExists("-noshortticfix"));
+    //[crispy] make shortticfix the default
 
     G_InitNew(skill, episode, map);
     usergame = false;
-    M_StringCopy(demoname, name, sizeof(demoname));
-    M_StringConcat(demoname, ".lmp", sizeof(demoname));
+    demoname_size = strlen(name) + 5 + 6; // [crispy] + 6 for "-00000"
+    demoname = Z_Malloc(demoname_size, PU_STATIC, NULL);
+    M_snprintf(demoname, demoname_size, "%s.lmp", name);
     maxsize = 0x20000;
+
+    // [crispy] prevent overriding demos by adding a file name suffix
+    for ( ; j <= 99999 && (fp = fopen(demoname, "rb")) != NULL; j++)
+    {
+	M_snprintf(demoname, demoname_size, "%s-%05d.lmp", name, j);
+	fclose (fp);
+    }
 
     //!
     // @arg <size>
@@ -2620,6 +2731,8 @@ static void G_DemoProgressBar (const int lumplength)
 ===================
 */
 
+static const char *defdemoname;
+
 void G_DeferedPlayDemo(const char *name)
 {
     defdemoname = name;
@@ -2692,7 +2805,7 @@ void G_DoPlayDemo(void)
 
     if (netgame == true)
     {
-        netdemo = true;
+      netdemo = true;
     }
 
     // [crispy] demo progress bar
@@ -2745,7 +2858,7 @@ void G_TimeDemo(char *name)
     if (playeringame[1] || M_CheckParm("-solo-net") > 0
                         || M_CheckParm("-netdemo") > 0)
     {
-        netgame = true;
+      netgame = true;
     }
 
     G_InitNew(skill, episode, map);
@@ -2758,13 +2871,131 @@ void G_TimeDemo(char *name)
 
     if (netgame == true)
     {
-        netdemo = true;
+      netdemo = true;
     }
 
     // [crispy] demo progress bar
     G_DemoProgressBar(lumplength);
 }
 
+#define DEMO_FOOTER_SEPARATOR "\n"
+#define NUM_DEMO_FOOTER_LUMPS 4
+
+static size_t WriteCmdLineLump(MEMFILE *stream)
+{
+    int i;
+    long pos;
+    char *tmp, **filenames;
+
+    filenames = W_GetWADFileNames();
+
+    pos = mem_ftell(stream);
+
+    tmp = M_StringJoin("-iwad \"", M_BaseName(filenames[0]), "\"", NULL);
+    mem_fputs(tmp, stream);
+    free(tmp);
+
+    if (filenames[1])
+    {
+        mem_fputs(" -file", stream);
+
+        for (i = 1; filenames[i]; i++)
+        {
+            tmp = M_StringJoin(" \"", M_BaseName(filenames[i]), "\"", NULL);
+            mem_fputs(tmp, stream);
+            free(tmp);
+        }
+    }
+
+    filenames = DEH_GetFileNames();
+
+    if (filenames)
+    {
+        mem_fputs(" -deh", stream);
+
+        for (i = 0; filenames[i]; i++)
+        {
+            tmp = M_StringJoin(" \"", M_BaseName(filenames[i]), "\"", NULL);
+            mem_fputs(tmp, stream);
+            free(tmp);
+        }
+    }
+
+    mem_fputs(" -complevel 0", stream);
+
+    if (M_CheckParm("-solo-net"))
+    {
+        mem_fputs(" -solo-net", stream);
+    }
+
+    return mem_ftell(stream) - pos;
+}
+
+static void WriteFileInfo(const char *name, size_t size, MEMFILE *stream)
+{
+    filelump_t fileinfo = { 0 };
+    static long filepos = sizeof(wadinfo_t);
+
+    fileinfo.filepos = LONG(filepos);
+    fileinfo.size = LONG(size);
+
+    if (name)
+    {
+        size_t len = strnlen(name, 8);
+        if (len < 8)
+        {
+            len++;
+        }
+        memcpy(fileinfo.name, name, len);
+    }
+
+    mem_fwrite(&fileinfo, 1, sizeof(fileinfo), stream);
+
+    filepos += size;
+}
+
+static void G_AddDemoFooter(void)
+{
+    byte *data;
+    size_t size;
+    char *project_string;
+
+    MEMFILE *stream = mem_fopen_write();
+
+    wadinfo_t header = { "PWAD" };
+    header.numlumps = LONG(NUM_DEMO_FOOTER_LUMPS);
+    mem_fwrite(&header, 1, sizeof(header), stream);
+
+    project_string = M_StringReplace(PACKAGE_STRING, "Doom", "Heretic");
+
+    mem_fputs(PACKAGE_FULLNAME_HERETIC, stream);  // [JN] Use full port name.
+    mem_fputs(DEMO_FOOTER_SEPARATOR, stream);
+    size = WriteCmdLineLump(stream);
+    mem_fputs(DEMO_FOOTER_SEPARATOR, stream);
+
+    header.infotableofs = LONG(mem_ftell(stream));
+    mem_fseek(stream, 0, MEM_SEEK_SET);
+    mem_fwrite(&header, 1, sizeof(header), stream);
+    mem_fseek(stream, 0, MEM_SEEK_END);
+
+    WriteFileInfo("PORTNAME", strlen(project_string), stream);
+    WriteFileInfo(NULL, strlen(DEMO_FOOTER_SEPARATOR), stream);
+    WriteFileInfo("CMDLINE", size, stream);
+    WriteFileInfo(NULL, strlen(DEMO_FOOTER_SEPARATOR), stream);
+
+    mem_get_buf(stream, (void **)&data, &size);
+
+    while (demo_p > demoend - size)
+    {
+        IncreaseDemoBuffer();
+    }
+
+    memcpy(demo_p, data, size);
+    demo_p += size;
+
+    free(project_string);
+    mem_fclose(stream);
+}
 
 /*
 ===================
@@ -2806,10 +3037,19 @@ boolean G_CheckDemoStatus(void)
     if (demorecording)
     {
         *demo_p++ = DEMOMARKER;
+        G_AddDemoFooter();
         M_WriteFile(demoname, demobuffer, demo_p - demobuffer);
         Z_Free(demobuffer);
         demorecording = false;
+        // [crispy] if a new game is started during demo recording, start a new demo
+        if (gameaction != ga_newgame)
+        {
         I_Error("Demo %s recorded", demoname);
+        }
+        else
+        {
+            fprintf(stderr, "Demo %s recorded\n", demoname);
+        }
     }
 
     return false;

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -5744,6 +5744,12 @@ boolean MN_Responder(event_t * event)
         {
             if (demoplayback)
             {
+                // [JN] TODO - trying to go to next level while paused state
+                // is restarting current level with demo desync. But why?
+                if (paused)
+                {
+                    return true;
+                }
                 // [JN] Go to next level.
                 demo_gotonextlvl = true;
                 G_DemoGoToNextLevel(true);

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -5721,13 +5721,35 @@ boolean MN_Responder(event_t * event)
         }
         // [crispy] those two can be considered as shortcuts for the IDCLEV cheat
         // and should be treated as such, i.e. add "if (!netgame)"
-        else if (!netgame && key != 0 && key == key_reloadlevel)
+        // [JN] Hovewer, allow while multiplayer demos.
+        else if ((!netgame || netdemo) && key != 0 && key == key_reloadlevel)
         {
+            if (demoplayback)
+            {
+                if (demowarp)
+                {
+                    // [JN] Enable screen render back before replaying.
+                    nodrawers = false;
+                    singletics = false;
+                }
+                // [JN] Replay demo lump or file.
+                G_DoPlayDemo();
+                return true;
+            }
+            else
             if (G_ReloadLevel())
             return true;
         }
-        else if (!netgame && key != 0 && key == key_nextlevel)
+        else if ((!netgame || netdemo) && key != 0 && key == key_nextlevel)
         {
+            if (demoplayback)
+            {
+                // [JN] Go to next level.
+                demo_gotonextlvl = true;
+                G_DemoGoToNextLevel(true);
+                return true;
+            }
+            else
             if (G_GotoNextLevel())
             return true;
         }

--- a/src/heretic/p_local.h
+++ b/src/heretic/p_local.h
@@ -119,6 +119,7 @@ void P_Thrust(player_t * player, angle_t angle, fixed_t move);
 void P_PlayerRemoveArtifact(player_t * player, int slot);
 void P_PlayerUseArtifact(player_t * player, artitype_t arti);
 boolean P_UseArtifact(player_t * player, artitype_t arti);
+boolean P_UndoPlayerChicken(player_t * player);
 int P_GetPlayerNum(player_t * player);
 
 // ***** P_MOBJ *****

--- a/src/heretic/p_mobj.c
+++ b/src/heretic/p_mobj.c
@@ -1073,6 +1073,13 @@ void P_SpawnPlayer(mapthing_t * mthing)
     mobj_t *mobj;
     int i;
 
+    // [JN] Stop fast forward after entering new level while demo playback.
+    if (demo_gotonextlvl)
+    {
+        demo_gotonextlvl = false;
+        G_DemoGoToNextLevel(false);
+    }
+
     if (!playeringame[mthing->type - 1])
         return;                 // not playing
 

--- a/src/heretic/p_setup.c
+++ b/src/heretic/p_setup.c
@@ -706,6 +706,14 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
     }
     players[consoleplayer].viewz = 1;   // will be set by player think
 
+    // [crispy] stop demo warp mode now
+    if (demowarp == map)
+    {
+        demowarp = 0;
+        nodrawers = false;
+        singletics = false;
+    }
+
     S_Start();                  // make sure all sounds are stopped before Z_FreeTags
 
     Z_FreeTags(PU_LEVEL, PU_PURGELEVEL - 1);

--- a/src/heretic/s_sound.c
+++ b/src/heretic/s_sound.c
@@ -90,8 +90,9 @@ void S_StartSong(int song, boolean loop)
 {
     int mus_len;
 
-    // [JN] CRL - do not play music while demo-warp.
-    if (nodrawers /*|| demowarp*/)
+    // [JN] Do not play music while demo-warp,
+    // but still change while fast forwarding to next level in demo playback.
+    if ((nodrawers || demowarp) && !demo_gotonextlvl)
     {
         return;
     }


### PR DESCRIPTION
To match up Crispy Heretic standards and few extras:
* Parameter `-demoextend` now default, allowing to record/watch longer than one level demo. Non-extended demo also stops while dead player is trying to respawn.
* Demo warp feature (i.e. support for warping like `inter-heretic.exe -playdemo hanoE1SMdemo-522.lmp -warp 1 4`).
* Demo footer with source port name and command line contents, including autoload. Must be a DSDA's established standard. 
* Special keys "Restart demo" and "Go to next level" now working as should while demo playback.
* `IDCLEV`/`ENGAGE` working while demo playback.
* Preventing of overriding demos by adding a file name suffix `-NNNNN`.
* It is possible to pause demo playback.