### PR TITLE
Heretic: add support for extended nodes + possible BLOCKMAP fix

### DIFF
--- a/src/heretic/CMakeLists.txt
+++ b/src/heretic/CMakeLists.txt
@@ -56,7 +56,7 @@ add_library(heretic STATIC
             s_sound.c           s_sound.h)
 
 target_include_directories(heretic PRIVATE "../" "${CMAKE_CURRENT_BINARY_DIR}/../../")
-target_link_libraries(heretic textscreen SDL2::SDL2)
+target_link_libraries(heretic textscreen SDL2::SDL2 miniz::miniz)
 if(ENABLE_SDL2_MIXER)
     target_link_libraries(heretic SDL2_mixer::SDL2_mixer)
 endif()

--- a/src/heretic/doomdata.h
+++ b/src/heretic/doomdata.h
@@ -64,10 +64,11 @@ typedef PACKED_STRUCT (
 
 typedef PACKED_STRUCT (
 {
-    short v1, v2;
-    short flags;
+    unsigned short v1, v2; // [crispy] extended nodes
+    unsigned short flags; // [crispy] extended nodes
     short special, tag;
-    short sidenum[2];           // sidenum[1] will be -1 if one sided
+    // sidenum[1] will be NO_INDEX if one sided
+    unsigned short sidenum[2]; // [crispy] extended nodes
 }) maplinedef_t;
 
 #define	ML_BLOCKING			1
@@ -99,25 +100,89 @@ typedef PACKED_STRUCT (
 
 typedef PACKED_STRUCT (
 {
-    short numsegs;
-    short firstseg;             // segs are stored sequentially
+    unsigned short numsegs; // [crispy] extended nodes
+    // segs are stored sequentially
+    unsigned short firstseg; // [crispy] extended nodes
 }) mapsubsector_t;
+
+// [crispy] allow loading of maps with DeePBSP nodes
+// taken from prboom-plus/src/doomdata.h:163-166
+typedef PACKED_STRUCT (
+{
+    unsigned short numsegs;
+    int firstseg;
+}) mapsubsector_deepbsp_t;
+
+// [crispy] allow loading of maps with ZDBSP nodes
+// taken from prboom-plus/src/doomdata.h:168-170
+typedef PACKED_STRUCT (
+{
+    unsigned int numsegs;
+}) mapsubsector_zdbsp_t;
 
 typedef PACKED_STRUCT (
 {
-    short v1, v2;
+    unsigned short v1, v2; // [crispy] extended nodes
     short angle;
-    short linedef, side;
+    unsigned short linedef; // [crispy] extended nodes
+    short side;
     short offset;
 }) mapseg_t;
 
-#define	NF_SUBSECTOR	0x8000
+// [crispy] allow loading of maps with DeePBSP nodes
+// taken from prboom-plus/src/doomdata.h:183-190
+typedef PACKED_STRUCT (
+{
+    int v1;
+    int v2;
+    unsigned short angle;
+    unsigned short linedef;
+    short side;
+    unsigned short offset;
+}) mapseg_deepbsp_t;
+
+// [crispy] allow loading of maps with ZDBSP nodes
+// taken from prboom-plus/src/doomdata.h:192-196
+typedef PACKED_STRUCT (
+{
+    unsigned int v1, v2;
+    unsigned short linedef;
+    unsigned char side;
+}) mapseg_zdbsp_t;
+
+#define	NF_SUBSECTOR_VANILLA	0x8000
+#define	NF_SUBSECTOR	0x80000000 // [crispy] extended nodes
+#define	NO_INDEX	((unsigned short)-1) // [crispy] extended nodes
 typedef PACKED_STRUCT (
 {
     short x, y, dx, dy;         // partition line
     short bbox[2][4];           // bounding box for each child
     unsigned short children[2]; // if NF_SUBSECTOR its a subsector
 }) mapnode_t;
+
+// [crispy] allow loading of maps with DeePBSP nodes
+// taken from prboom-plus/src/doomdata.h:216-225
+typedef PACKED_STRUCT (
+{
+    short x;
+    short y;
+    short dx;
+    short dy;
+    short bbox[2][4];
+    int children[2];
+}) mapnode_deepbsp_t;
+
+// [crispy] allow loading of maps with ZDBSP nodes
+// taken from prboom-plus/src/doomdata.h:227-136
+typedef PACKED_STRUCT (
+{
+    short x;
+    short y;
+    short dx;
+    short dy;
+    short bbox[2][4];
+    int children[2];
+}) mapnode_zdbsp_t;
 
 typedef PACKED_STRUCT (
 {

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -3201,7 +3201,7 @@ static void M_ID_SmoothLightingHook (void)
     // [crispy] re-calculate the scalelight[][] array
     R_ExecuteSetViewSize();
     // [crispy] re-calculate fake contrast
-    P_SegLengths(true);
+    P_SegLengths();
 }
 
 static boolean M_ID_SmoothLighting (int choice)

--- a/src/heretic/p_local.h
+++ b/src/heretic/p_local.h
@@ -253,11 +253,11 @@ extern int numspechit;
 
 // ***** P_SETUP *****
 
-extern void P_SegLengths (boolean contrast_only);
+extern void P_SegLengths (void);
 
 extern byte *rejectmatrix;      // for fast sight rejection
-extern short *blockmaplump;     // offsets in blockmap are from here
-extern short *blockmap;
+extern int32_t *blockmaplump;   // offsets in blockmap are from here // [crispy] BLOCKMAP limit
+extern int32_t *blockmap;       // [crispy] BLOCKMAP limit
 extern int bmapwidth, bmapheight;       // in mapblocks
 extern fixed_t bmaporgx, bmaporgy;      // origin of block map
 extern mobj_t **blocklinks;     // for thing chains

--- a/src/heretic/p_maputl.c
+++ b/src/heretic/p_maputl.c
@@ -267,7 +267,7 @@ void P_LineOpening(line_t * linedef)
 {
     sector_t *front, *back;
 
-    if (linedef->sidenum[1] == -1)
+    if (linedef->sidenum[1] == NO_INDEX) // [crispy] extended nodes
     {                           // single sided line
         openrange = 0;
         return;
@@ -431,7 +431,7 @@ If the function returns false, exit with false without checking anything else.
 boolean P_BlockLinesIterator(int x, int y, boolean(*func) (line_t *))
 {
     int offset;
-    short *list;
+    int32_t *list; // [crispy] BLOCKMAP limit
     line_t *ld;
 
     if (x < 0 || y < 0 || x >= bmapwidth || y >= bmapheight)

--- a/src/heretic/p_setup.c
+++ b/src/heretic/p_setup.c
@@ -104,33 +104,43 @@ mapformat_t P_CheckMapFormat(int lumpnum)
     byte *nodes = NULL;
     int b;
 
-    if (!((b = lumpnum + ML_NODES) < numlumps &&
-          (nodes = W_CacheLumpNum(b, PU_CACHE)) &&
-          W_LumpLength(b) > 0))
+    /*
+    if ((b = lumpnum+ML_BLOCKMAP+1) < numlumps &&
+        !strncasecmp(lumpinfo[b]->name, "BEHAVIOR", 8))
     {
-        fprintf(stderr, "no nodes");
-    }
-    else if (!memcmp(nodes, "xNd4\0\0\0\0", 8))
-    {
-        fprintf(stderr, "DeePBSP nodes");
-        format |= MFMT_DEEPBSP;
-    }
-    else if (!memcmp(nodes, "XNOD", 4))
-    {
-        fprintf(stderr, "ZDBSP nodes");
-        format |= MFMT_ZDBSPX;
-    }
-    else if (!memcmp(nodes, "ZNOD", 4))
-    {
-        fprintf(stderr, "compressed ZDBSP nodes");
-        format |= MFMT_ZDBSPZ;
+	fprintf(stderr, "Hexen format (");
+	format |= MFMT_HEXEN;
     }
     else
-    {
-        fprintf(stderr, "BSP nodes");
-    }
+    */
+	fprintf(stderr, "Heretic format (");
 
-    fprintf(stderr, " are detected\n");
+    if (!((b = lumpnum+ML_NODES) < numlumps &&
+        (nodes = W_CacheLumpNum(b, PU_CACHE)) &&
+        W_LumpLength(b) > 0))
+	fprintf(stderr, "no nodes");
+    else
+    if (!memcmp(nodes, "xNd4\0\0\0\0", 8))
+    {
+	fprintf(stderr, "DeePBSP");
+	format |= MFMT_DEEPBSP;
+    }
+    else
+    if (!memcmp(nodes, "XNOD", 4))
+    {
+	fprintf(stderr, "ZDBSP");
+	format |= MFMT_ZDBSPX;
+    }
+    else
+    if (!memcmp(nodes, "ZNOD", 4))
+    {
+	fprintf(stderr, "compressed ZDBSP");
+	format |= MFMT_ZDBSPZ;
+    }
+    else
+	fprintf(stderr, "BSP");
+
+    fprintf(stderr, "), ");
 
     if (nodes)
     {
@@ -1200,6 +1210,9 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
     realleveltime = 0;
     oldleveltime = 0;  // [crispy] Track if game is running
 
+    // [JN] Indicate the map we are loading.
+    fprintf(stderr, "P_SetupLevel: E%dM%d, ", gameepisode, gamemap);
+
     lumpnum = W_GetNumForName(lumpname);
 
     // [crispy] check and log map and nodes format
@@ -1296,8 +1309,7 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
     crl_spectating = 0;
 
     // [JN] Print amount of level loading time.
-    printf("P_SetupLevel: E%dM%d, loaded in %d ms.\n",
-           gameepisode, gamemap, SDL_GetTicks() - starttime);
+    printf("loaded in %d ms.\n", SDL_GetTicks() - starttime);
 
 //printf ("free memory: 0x%x\n", Z_FreeMemory());
 

--- a/src/heretic/p_setup.c
+++ b/src/heretic/p_setup.c
@@ -967,15 +967,20 @@ void P_LoadSideDefs(int lump)
 =================
 */
 
-void P_LoadBlockMap(int lump)
+boolean P_LoadBlockMap(int lump)
 {
     int i, count;
     int lumplen;
     short *wadblockmaplump;
 
-    lumplen = W_LumpLength(lump);
-
-    count = lumplen / 2; // [crispy] remove BLOCKMAP limit
+    // [crispy] (re-)create BLOCKMAP if necessary
+    if (M_CheckParm("-blockmap") ||
+        lump >= numlumps ||
+        (lumplen = W_LumpLength(lump)) < 8 ||
+        (count = lumplen / 2) >= 0x10000)
+    {
+	return false;
+    }
 
     // [crispy] remove BLOCKMAP limit
     wadblockmaplump = Z_Malloc(lumplen, PU_LEVEL, NULL);
@@ -1008,8 +1013,187 @@ void P_LoadBlockMap(int lump)
     count = sizeof(*blocklinks) * bmapwidth * bmapheight;
     blocklinks = Z_Malloc(count, PU_LEVEL, 0);
     memset(blocklinks, 0, count);
+
+    return true;
 }
 
+
+// -----------------------------------------------------------------------------
+// P_CreateBlockMap
+// [crispy] taken from mbfsrc/P_SETUP.C:547-707, slightly adapted
+// -----------------------------------------------------------------------------
+
+static void P_CreateBlockMap (void)
+{
+    int i;
+    fixed_t minx = INT_MAX, miny = INT_MAX, maxx = INT_MIN, maxy = INT_MIN;
+
+    // First find limits of map
+
+    for (i=0; i<numvertexes; i++)
+    {
+        if (vertexes[i].x >> FRACBITS < minx)
+        {
+            minx = vertexes[i].x >> FRACBITS;
+        }
+        else if (vertexes[i].x >> FRACBITS > maxx)
+        {
+            maxx = vertexes[i].x >> FRACBITS;
+        }
+        if (vertexes[i].y >> FRACBITS < miny)
+        {
+            miny = vertexes[i].y >> FRACBITS;
+        }
+        else if (vertexes[i].y >> FRACBITS > maxy)
+        {
+            maxy = vertexes[i].y >> FRACBITS;
+        }
+    }
+
+    // Save blockmap parameters
+
+    bmaporgx = minx << FRACBITS;
+    bmaporgy = miny << FRACBITS;
+    bmapwidth  = ((maxx-minx) >> MAPBTOFRAC) + 1;
+    bmapheight = ((maxy-miny) >> MAPBTOFRAC) + 1;
+
+    // Compute blockmap, which is stored as a 2d array of variable-sized lists.
+    //
+    // Pseudocode:
+    //
+    // For each linedef:
+    //
+    //   Map the starting and ending vertices to blocks.
+    //
+    //   Starting in the starting vertex's block, do:
+    //
+    //     Add linedef to current block's list, dynamically resizing it.
+    //
+    //     If current block is the same as the ending vertex's block, exit loop.
+    //
+    //     Move to an adjacent block by moving towards the ending block in
+    //     either the x or y direction, to the block which contains the linedef.
+
+    {
+        typedef struct { int n, nalloc, *list; } bmap_t;  // blocklist structure
+        unsigned tot = bmapwidth * bmapheight;            // size of blockmap
+        bmap_t *bmap = calloc(sizeof *bmap, tot);         // array of blocklists
+        int x, y, adx, ady, bend;
+
+        for (i=0; i < numlines; i++)
+        {
+            int dx, dy, diff, b;
+
+            // starting coordinates
+            x = (lines[i].v1->x >> FRACBITS) - minx;
+            y = (lines[i].v1->y >> FRACBITS) - miny;
+
+            // x-y deltas
+            adx = lines[i].dx >> FRACBITS, dx = adx < 0 ? -1 : 1;
+            ady = lines[i].dy >> FRACBITS, dy = ady < 0 ? -1 : 1;
+
+            // difference in preferring to move across y (>0) instead of x (<0)
+            diff = !adx ? 1 : !ady ? -1 :
+            (((x >> MAPBTOFRAC) << MAPBTOFRAC) +
+            (dx > 0 ? MAPBLOCKUNITS-1 : 0) - x) * (ady = abs(ady)) * dx -
+            (((y >> MAPBTOFRAC) << MAPBTOFRAC) +
+            (dy > 0 ? MAPBLOCKUNITS-1 : 0) - y) * (adx = abs(adx)) * dy;
+
+            // starting block, and pointer to its blocklist structure
+            b = (y >> MAPBTOFRAC)*bmapwidth + (x >> MAPBTOFRAC);
+
+            // ending block
+            bend = (((lines[i].v2->y >> FRACBITS) - miny) >> MAPBTOFRAC)
+                 * bmapwidth + (((lines[i].v2->x >> FRACBITS) - minx) >> MAPBTOFRAC);
+
+            // delta for pointer when moving across y
+            dy *= bmapwidth;
+
+            // deltas for diff inside the loop
+            adx <<= MAPBTOFRAC;
+            ady <<= MAPBTOFRAC;
+
+            // Now we simply iterate block-by-block until we reach the end block.
+            while ((unsigned) b < tot)    // failsafe -- should ALWAYS be true
+            {
+                // Increase size of allocated list if necessary
+                if (bmap[b].n >= bmap[b].nalloc)
+                    bmap[b].list = I_Realloc(bmap[b].list,
+                   (bmap[b].nalloc = bmap[b].nalloc ?
+                    bmap[b].nalloc*2 : 8)*sizeof*bmap->list);
+
+                // Add linedef to end of list
+                bmap[b].list[bmap[b].n++] = i;
+
+                // If we have reached the last block, exit
+                if (b == bend)
+                {
+                    break;
+                }
+
+                // Move in either the x or y direction to the next block
+                if (diff < 0)
+                {
+                    diff += ady, b += dx;
+                }
+                else
+                {
+                    diff -= adx, b += dy;
+                }
+            }
+        }
+
+        // Compute the total size of the blockmap.
+        //
+        // Compression of empty blocks is performed by reserving two offset words
+        // at tot and tot+1.
+        //
+        // 4 words, unused if this routine is called, are reserved at the start.
+
+        {
+            int count = tot+6;  // we need at least 1 word per block, plus reserved's
+        
+            for (unsigned int t = 0; t < tot; t++)
+                if (bmap[t].n)
+                    count += bmap[t].n + 2; // 1 header word + 1 trailer word + blocklist
+        
+            // Allocate blockmap lump with computed count
+            blockmaplump = Z_Malloc(sizeof(*blockmaplump) * count, PU_LEVEL, 0);
+        }
+
+        // Now compress the blockmap.
+        {
+            int ndx = tot += 4;         // Advance index to start of linedef lists
+            bmap_t *bp = bmap;          // Start of uncompressed blockmap
+
+            blockmaplump[ndx++] = 0;    // Store an empty blockmap list at start
+            blockmaplump[ndx++] = -1;   // (Used for compression)
+
+            for (unsigned int t = 4; t < tot; t++, bp++)
+                if (bp->n)                                      // Non-empty blocklist
+                {
+                    blockmaplump[blockmaplump[t] = ndx++] = 0;  // Store index & header
+                    do
+                    blockmaplump[ndx++] = bp->list[--bp->n];    // Copy linedef list
+                    while (bp->n);
+                    blockmaplump[ndx++] = -1;                   // Store trailer
+                    free(bp->list);                             // Free linedef list
+                }
+                else            // Empty blocklist: point to reserved empty blocklist
+                blockmaplump[t] = tot;
+        
+            free(bmap);    // Free uncompressed blockmap
+        }
+    }
+
+    // [crispy] copied over from P_LoadBlockMap()
+    {
+        int count = sizeof(*blocklinks) * bmapwidth * bmapheight;
+        blocklinks = Z_Malloc(count, PU_LEVEL, 0);
+        memset(blocklinks, 0, count);
+        blockmap = blockmaplump+4;
+    }
+}
 
 
 
@@ -1172,6 +1356,7 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
     char lumpname[9];
     int lumpnum;
     mobj_t *mobj;
+    boolean	crispy_validblockmap;
     mapformat_t crispy_mapformat;
     // [JN] CRL - indicate level loading time in console.
     const int starttime = SDL_GetTicks();
@@ -1221,12 +1406,18 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
     maplumpinfo = lumpinfo[lumpnum];
 
 // note: most of this ordering is important     
-    P_LoadBlockMap(lumpnum + ML_BLOCKMAP);
+    crispy_validblockmap = P_LoadBlockMap (lumpnum+ML_BLOCKMAP); // [crispy] (re-)create BLOCKMAP if necessary
     P_LoadVertexes(lumpnum + ML_VERTEXES);
     P_LoadSectors(lumpnum + ML_SECTORS);
     P_LoadSideDefs(lumpnum + ML_SIDEDEFS);
 
     P_LoadLineDefs(lumpnum + ML_LINEDEFS);
+
+    // [crispy] (re-)create BLOCKMAP if necessary
+    if (!crispy_validblockmap)
+    {
+        P_CreateBlockMap();
+    }
 
     if (crispy_mapformat & (MFMT_ZDBSPX | MFMT_ZDBSPZ))
     {

--- a/src/heretic/p_setup.c
+++ b/src/heretic/p_setup.c
@@ -2,6 +2,7 @@
 // Copyright(C) 1993-1996 Id Software, Inc.
 // Copyright(C) 1993-2008 Raven Software
 // Copyright(C) 2005-2014 Simon Howard
+// Copyright(C) 2015-2018 Fabian Greffrath
 // Copyright(C) 2016-2024 Julia Nechaevskaya
 //
 // This program is free software; you can redistribute it and/or

--- a/src/heretic/p_sight.c
+++ b/src/heretic/p_sight.c
@@ -92,7 +92,7 @@ boolean PTR_SightTraverse(intercept_t * in)
 boolean P_SightBlockLinesIterator(int x, int y)
 {
     int offset;
-    short *list;
+    int32_t *list;
     line_t *ld;
     int s1, s2;
     divline_t dl;

--- a/src/heretic/r_local.h
+++ b/src/heretic/r_local.h
@@ -127,9 +127,10 @@ typedef struct line_s
 {
     vertex_t *v1, *v2;
     fixed_t dx, dy;             // v2 - v1 for side checking
-    short flags;
+    unsigned short flags; // [crispy] extended nodes
     short special, tag;
-    short sidenum[2];           // sidenum[1] will be -1 if one sided
+    // sidenum[1] will be NO_INDEX if one sided
+    unsigned short sidenum[2]; // [crispy] extended nodes
     fixed_t bbox[4];
     slopetype_t slopetype;      // to aid move clipping
     sector_t *frontsector, *backsector;
@@ -152,8 +153,8 @@ typedef struct line_s
 typedef struct subsector_s
 {
     sector_t *sector;
-    short numlines;
-    short firstline;
+    int numlines; // [crispy] extended nodes
+    int firstline; // [crispy] extended nodes
 } subsector_t;
 
 typedef struct
@@ -174,7 +175,8 @@ typedef struct
 {
     fixed_t x, y, dx, dy;       // partition line
     fixed_t bbox[2][4];         // bounding box for each child
-    unsigned short children[2]; // if NF_SUBSECTOR its a subsector
+    // if NF_SUBSECTOR its a subsector
+    int children[2]; // [crispy] extended nodes
 } node_t;
 
 


### PR DESCRIPTION
* Support for DeePBSP and ZDBSP (compressed and uncompressed).
* `BLOCKMAP` recreation if necessary.
* Updated old code of `P_GroupLines` (from Doom 1.2?) with actual one, loading a map with size of Sunder map15 takes not **6** seconds, but just **350** milliseconds.