### PR TITLE
Sound fixes for Heretic's "flipped levels" and "disable render when minimized"

### DIFF
--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -363,12 +363,6 @@ void D_DoomLoop(void)
         // Will run at least one tic
         TryRunTics();
 
-        // Update display, next frame, with current state.
-        if (screenvisible)
-        {
-            D_Display();
-        }
-
         // Move positional sounds
         if (oldgametic < gametic)
         {
@@ -381,6 +375,13 @@ void D_DoomLoop(void)
             S_UpdateSounds(players[consoleplayer].mo);
             oldgametic = gametic;
         }
+
+        // Update display, next frame, with current state.
+        if (screenvisible)
+        {
+            D_Display();
+        }
+
     }
 }
 

--- a/src/heretic/s_sound.c
+++ b/src/heretic/s_sound.c
@@ -170,7 +170,7 @@ void S_StartSound(void *_origin, int sound_id)
     int i;
     int priority;
     int sep;
-    int64_t angle;
+    int angle;
     int64_t absx;
     int64_t absy;
     int64_t absz;  // [JN] Z-axis sfx distance
@@ -313,7 +313,7 @@ void S_StartSound(void *_origin, int sound_id)
                                 origin->x, origin->y);
         angle = (angle - viewangle) >> 24;
         if (gp_flip_levels)
-            angle = -angle;
+            angle = 255 - angle;
         sep = angle * 2 - 128;
         if (sep < 64)
             sep = -sep;
@@ -494,7 +494,7 @@ void S_ResumeSound(void)
 void S_UpdateSounds(mobj_t * listener)
 {
     int i, dist, vol;
-    int64_t angle;
+    int angle;
     int sep;
     int priority;
     int64_t absx;
@@ -568,7 +568,7 @@ void S_UpdateSounds(mobj_t * listener)
                                         channel[i].mo->x, channel[i].mo->y);
                 angle = (angle - viewangle) >> 24;
                 if (gp_flip_levels)
-                    angle = -angle;
+                    angle = 255 - angle;
                 sep = angle * 2 - 128;
                 if (sep < 64)
                     sep = -sep;


### PR DESCRIPTION
Using (255 - angle) for the flipped sound angle seems right, and lets you return to using int for the sound angle.

Moving the display update back to being after the sound update avoids many clicks where the first tic of the sound is played at angle 0. This is a bug introduced with commit 862475c.

For an example of the above, try this map without the fix. Move back and fire the hellstaff, many of the shots will click in the left channel only briefly, before going back to the centre channel. Happens more frequently with uncapped framerates.

[hsnd.zip](https://github.com/JNechaevsky/international-doom/files/13891140/hsnd.zip)

I've played a few episodes with this applied now and it fixes *most* of the sound issues. There is still the occasional click towards angle 0, so a more robust fix might be needed at some time. 