### PR TITLE
Separate ID-specific binds per games

### DIFF
--- a/src/doom/ct_chat.c
+++ b/src/doom/ct_chat.c
@@ -34,6 +34,8 @@
 #include "z_zone.h"
 #include "sounds.h"
 
+#include "id_vars.h"
+
 
 #define QUEUESIZE       128
 #define MESSAGESIZE     128
@@ -473,7 +475,7 @@ void CT_SetMessage (player_t *player, const char *message, boolean ultmsg, byte 
 {
     lastmessage = message;
 
-    if ((ultimatemsg || !showMessages) && !ultmsg)
+    if ((ultimatemsg || !msg_show) && !ultmsg)
     {
         return;
     }

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -121,16 +121,6 @@ boolean nerve = false;
 // [JN] Check for available SSG from Crispy Doom.
 boolean havessg = false;
 
-// -----------------------------------------------------------------------------
-// [JN] Defaulted values
-// -----------------------------------------------------------------------------
-
-int vid_diskicon = 1;
-int vid_endoom = 0;       // [JN] Disabled by default
-int dp_detail_level = 0;  // Blocky mode, has default, 0 = high, 1 = normal
-int showMessages = 1;     // Show messages has default, 0 = off, 1 = on
-int mouseSensitivity = 5;
-
 
 // -----------------------------------------------------------------------------
 // D_ProcessEvents
@@ -460,13 +450,8 @@ void D_BindVariables(void)
     NET_BindVariables();
 
     M_BindIntVariable("key_message_refresh",    &key_message_refresh);
-    M_BindIntVariable("mouse_sensitivity",      &mouseSensitivity);
     M_BindIntVariable("sfx_volume",             &sfxVolume);
     M_BindIntVariable("music_volume",           &musicVolume);
-    M_BindIntVariable("msg_show",               &showMessages);
-    M_BindIntVariable("dp_detail_level",        &dp_detail_level);
-    M_BindIntVariable("snd_channels",           &snd_channels);
-    M_BindIntVariable("vid_endoom",             &vid_endoom);
 
     // Multiplayer chat macros
 
@@ -479,7 +464,7 @@ void D_BindVariables(void)
     }
 
 	// [JN] Bind ID-specific config variables.
-	ID_BindVariables();
+	ID_BindVariables(doom);
 }
 
 //
@@ -1593,6 +1578,9 @@ void D_DoomMain (void)
     M_SetConfigFilenames(PROGRAM_PREFIX "doom.ini");
     D_BindVariables();
     M_LoadDefaults();
+
+    // [JN] Disk icon can be enabled for Doom.
+    diskicon_enabled = true;
 
 #ifdef _WIN32
     // [JN] Pressing PrintScreen on Windows 11 is opening Snipping Tool.

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -449,6 +449,7 @@ void D_BindVariables(void)
 
     NET_BindVariables();
 
+    // [JN] Game-dependent variables:
     M_BindIntVariable("key_message_refresh",    &key_message_refresh);
     M_BindIntVariable("sfx_volume",             &sfxVolume);
     M_BindIntVariable("music_volume",           &musicVolume);

--- a/src/doom/d_main.h
+++ b/src/doom/d_main.h
@@ -47,8 +47,6 @@ extern void D_StartTitle (void);
 // GLOBAL VARIABLES
 //
 
-extern int dp_detail_level;
-
 extern boolean advancedemo;
 extern boolean sigil;
 extern boolean sigil2;

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -4241,8 +4241,10 @@ static void M_ID_LevelRespMonsters (int choice)
 
 static void M_ID_ApplyResetHook (void)
 {
+    //
+    // Video options
+    //
 
-    // Video
 #ifdef CRISPY_TRUECOLOR
     vid_truecolor = 0;
 #endif
@@ -4253,33 +4255,36 @@ static void M_ID_ApplyResetHook (void)
     vid_vsync = 1;
     vid_showfps = 0;
     vid_smooth_scaling = 0;
-    vid_gamma = 10;
-    vid_fov = 90;
-
     // Miscellaneous
     vid_screenwipe = 1;
     vid_diskicon = 1;
     vid_endoom = 0;
 
-    // Display
+    //
+    // Display options
+    //
+
     dp_screen_size = 10;
     dp_detail_level = 0;
+    vid_gamma = 10;
+    vid_fov = 90;
     dp_menu_shading = 0;
     dp_level_brightness = 0;
-
     // Color settings
     vid_saturation = 100;
     vid_r_intensity = 1.000000;
     vid_g_intensity = 1.000000;
     vid_b_intensity = 1.000000;
-
     // Messages settings
     msg_show = 1;
     msg_alignment = 0;
     msg_text_shadows = 0;
     msg_local_time = 0;
 
-    // Sound
+    //
+    // Sound options
+    //
+
     sfxVolume = 8;
     musicVolume = 8;
     snd_sfxdevice = 3;
@@ -4290,7 +4295,10 @@ static void M_ID_ApplyResetHook (void)
     snd_channels = 8;
     snd_mute_inactive = 0;
 
-    // Widgets
+    //
+    // Widgets and automap
+    //
+
     widget_location = 0;
     widget_kis = 0;
     widget_time = 0;
@@ -4299,7 +4307,6 @@ static void M_ID_ApplyResetHook (void)
     widget_coords = 0;
     widget_render = 0;
     widget_health = 0;
-
     // Automap
     automap_scheme = 0;
     automap_smooth = 0;
@@ -4308,7 +4315,11 @@ static void M_ID_ApplyResetHook (void)
     automap_overlay = 0;
     automap_shading = 0;
 
+    //
     // Gameplay features
+    //
+
+    // Visual
     vis_brightmaps = 0;
     vis_translucency = 0;
     vis_fake_contrast = 1;
@@ -4319,27 +4330,41 @@ static void M_ID_ApplyResetHook (void)
     vis_invul_sky = 0;
     vis_linear_sky = 0;
     vis_flip_corpses = 0;
+
+    // Crosshair
     xhair_draw = 0;
     xhair_color = 0;
+
+    // Status bar
     st_colored_stbar = 0;
     st_negative_health = 0;
     st_blinking_keys = 0;
+
+    // Audible
     aud_z_axis_sfx = 0;
     aud_full_sounds = 0;
     aud_exit_sounds = 0;
+
+    // Physical
     phys_torque = 0;
     phys_ssg_tear_monsters = 0;
     phys_toss_drop = 0;
     phys_floating_powerups = 0;
     phys_weapon_alignment = 0;
+    phys_breathing = 0;
+
+    // Gameplay
     gp_default_skill = 2;
     gp_revealed_secrets = 0;
-    phys_breathing = 0;
     gp_flip_levels = 0;
+
+    // Demos
     demo_timer = 0;
     demo_timerdir = 0;
     demo_bar = 0;
     demo_internal = 1;
+
+    // Compatibility-breaking
     compat_pistol_start = 0;
     compat_blockmap_fix = 0;
     compat_vertical_aiming = 0;

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1527,9 +1527,9 @@ static void M_Draw_ID_Display (void)
     M_WriteTextCentered(117, "MESSAGES SETTINGS", cr[CR_YELLOW]);
 
     // Messages enabled
-    sprintf(str, showMessages ? "ON" : "OFF");
+    sprintf(str, msg_show ? "ON" : "OFF");
     M_WriteText (M_ItemRightAlign(str), 126, str,
-                 M_Item_Glow(12, showMessages ? GLOW_DARKRED : GLOW_GREEN));
+                 M_Item_Glow(12, msg_show ? GLOW_DARKRED : GLOW_GREEN));
 
     // Messages alignment
     sprintf(str, msg_alignment == 1 ? "STATUS BAR" :
@@ -4274,7 +4274,7 @@ static void M_ID_ApplyResetHook (void)
     vid_b_intensity = 1.000000;
 
     // Messages settings
-    showMessages = 1;
+    msg_show = 1;
     msg_alignment = 0;
     msg_text_shadows = 0;
     msg_local_time = 0;
@@ -4874,10 +4874,10 @@ static void M_Episode(int choice)
 //
 static void M_ChangeMessages(int choice)
 {
-    showMessages ^= 1;
+    msg_show ^= 1;
 	
 	CT_SetMessage(&players[consoleplayer],
-                   DEH_String(showMessages ? MSGON : MSGOFF), true, NULL);
+                   DEH_String(msg_show ? MSGON : MSGOFF), true, NULL);
 }
 
 

--- a/src/doom/s_sound.c
+++ b/src/doom/s_sound.c
@@ -113,10 +113,6 @@ static musicinfo_t *mus_playing = NULL;
 
 #define MAX_SND_CHANNELS 16
 
-// Number of channels to use
-
-int snd_channels = 8;
-
 // [JN] External music number, used for music playback hot-swapping.
 int current_mus_num;
 

--- a/src/doom/s_sound.h
+++ b/src/doom/s_sound.h
@@ -88,7 +88,6 @@ extern void S_ChangeSFXSystem (void);
 extern void S_UpdateStereoSeparation (void);
 extern void S_MuteUnmuteSound (boolean mute);
 
-extern int snd_channels;
 extern int current_mus_num;
 
 // [JN] jff 3/17/98 holds last IDMUS number, or -1

--- a/src/heretic/ct_chat.c
+++ b/src/heretic/ct_chat.c
@@ -34,6 +34,8 @@
 #include "i_timer.h"
 #include "ct_chat.h"
 
+#include "id_vars.h"
+
 
 #define QUEUESIZE		128
 #define MESSAGESIZE     128
@@ -466,7 +468,7 @@ void CT_SetMessage (player_t *player, const char *message, boolean ultmsg)
 {
     lastmessage = message;
 
-    if ((ultimatemsg || !showMessages) && !ultmsg)
+    if ((ultimatemsg || !msg_show) && !ultmsg)
     {
         return;
     }

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -794,6 +794,7 @@ void D_BindVariables(void)
 
     NET_BindVariables();
 
+    // [JN] Game-dependent variables:
     M_BindIntVariable("key_message_refresh",    &key_message_refresh_hr);
     M_BindIntVariable("sfx_volume",             &snd_MaxVolume);
     M_BindIntVariable("music_volume",           &snd_MusicVolume);

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -54,6 +54,7 @@
 #include "p_local.h"
 #include "s_sound.h"
 #include "w_main.h"
+#include "v_diskicon.h"
 #include "v_trans.h"
 #include "v_video.h"
 #include "am_map.h"
@@ -86,10 +87,6 @@ static boolean main_loop_started = false;
 boolean autostart;
 
 boolean advancedemo;
-
-int vid_diskicon = 0;
-int vid_endoom = 0;
-int showMessages = 1;     // Show messages has default, 0 = off, 1 = on
 
 void D_ConnectNetGame(void);
 void D_CheckNetGame(void);
@@ -798,11 +795,8 @@ void D_BindVariables(void)
     NET_BindVariables();
 
     M_BindIntVariable("key_message_refresh",    &key_message_refresh_hr);
-    M_BindIntVariable("mouse_sensitivity",      &mouseSensitivity);
     M_BindIntVariable("sfx_volume",             &snd_MaxVolume);
     M_BindIntVariable("music_volume",           &snd_MusicVolume);
-    M_BindIntVariable("msg_show",               &showMessages);
-    M_BindIntVariable("snd_channels",           &snd_Channels);
     //M_BindIntVariable("graphical_startup",      &graphical_startup);
 
     // Multiplayer chat macros
@@ -816,10 +810,7 @@ void D_BindVariables(void)
     }
 
 	// [JN] Bind ID-specific config variables.
-	ID_BindVariables();
-
-    // TODO - bind Heretic variables!
-    M_BindIntVariable("st_ammo_widget",           &st_ammo_widget);
+	ID_BindVariables(heretic);
 }
 
 // 
@@ -1003,6 +994,9 @@ void D_DoomMain(void)
     D_BindVariables();
     M_SetConfigFilenames(PROGRAM_PREFIX "heretic.ini");
     M_LoadDefaults();
+
+    // [JN] Disk icon can't be enabled for Heretic.
+    diskicon_enabled = false;
 
     I_AtExit(M_SaveDefaults, true); // [crispy] always save configuration at exit
 

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -124,8 +124,6 @@ int totaltimes, totalleveltimes; // [crispy] CPhipps - total time for all comple
 
 boolean finalintermission; // [crispy] track intermission at end of episode
 
-int mouseSensitivity = 5;
-
 char *demoname;
 static const char *orig_demoname = NULL; // [crispy] the name originally chosen for the demo, i.e. without "-00000"
 boolean demorecording;

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -4142,7 +4142,10 @@ static boolean M_ID_LevelArti_9 (int choice)
 
 static void M_ID_ApplyResetHook (void)
 {
-    // Video
+    //
+    // Video options
+    //
+
 #ifdef CRISPY_TRUECOLOR
     vid_truecolor = 0;
 #endif
@@ -4153,23 +4156,31 @@ static void M_ID_ApplyResetHook (void)
     vid_vsync = 1;
     vid_showfps = 0;
     vid_smooth_scaling = 0;
+    // Miscellaneous
     vid_endoom = 0;
 
-    // Display
+    //
+    // Display options
+    //
+    dp_screen_size = 10;
     vid_gamma = 10;
     vid_fov = 90;
-    dp_screen_size = 10;    
     dp_menu_shading = 0;
     dp_level_brightness = 0;
+    // Color settings
     vid_saturation = 100;
     vid_r_intensity = 1.000000;
     vid_g_intensity = 1.000000;
     vid_b_intensity = 1.000000;
+    // Messages Settings
     msg_show = 1;
     msg_text_shadows = 0;
     msg_local_time = 0;
 
-    // Sound
+    //
+    // Sound options
+    //
+
     snd_MaxVolume = 10;
     snd_MusicVolume = 10;
     snd_monosfx = 0;
@@ -4177,7 +4188,10 @@ static void M_ID_ApplyResetHook (void)
     snd_channels = 8;
     snd_mute_inactive = 0;
 
-    // Widgets
+    //
+    // Widgets and automap
+    //
+
     widget_location = 0;
     widget_kis = 0;
     widget_time = 0;
@@ -4186,14 +4200,17 @@ static void M_ID_ApplyResetHook (void)
     widget_coords = 0;
     widget_render = 0;
     widget_health = 0;
-
     // Automap
     automap_secrets = 0;
     automap_rotate = 0;
     automap_overlay = 0;
     automap_shading = 0;
 
+    //
     // Gameplay features
+    //
+
+    // Visual
     vis_brightmaps = 0;
     vis_translucency = 0;
     vis_fake_contrast = 1;
@@ -4202,21 +4219,35 @@ static void M_ID_ApplyResetHook (void)
     vis_invul_sky = 0;
     vis_linear_sky = 0;
     vis_flip_corpses = 0;
+
+    // Crosshair
     xhair_draw = 0;
     xhair_color = 0;
+
+    // Status bar
     st_colored_stbar = 0;
     st_ammo_widget = 0;
+
+    // Audible
     aud_z_axis_sfx = 0;
+
+    // Physical
     phys_torque = 0;
     phys_weapon_alignment = 0;
     phys_breathing = 0;
+
+    // Gameplay
     gp_default_skill = 2;
     gp_revealed_secrets = 0;
     gp_flip_levels = 0;
+
+    // Demos
     demo_timer = 0;
     demo_timerdir = 0;
     demo_bar = 0;
     demo_internal = 1;
+
+    // Compatibility-breaking
     compat_pistol_start = 0;
     compat_blockmap_fix = 0;
 

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -1282,9 +1282,9 @@ static void M_Draw_ID_Display (void)
     MN_DrTextACentered("MESSAGES SETTINGS", 110, cr[CR_YELLOW]);
 
     // Messages enabled
-    sprintf(str, showMessages ? "ON" : "OFF");
+    sprintf(str, msg_show ? "ON" : "OFF");
     MN_DrTextA(str, M_ItemRightAlign(str), 120,
-               M_Item_Glow(10, showMessages ? GLOW_DARKRED : GLOW_GREEN));
+               M_Item_Glow(10, msg_show ? GLOW_DARKRED : GLOW_GREEN));
 
     // Text casts shadows
     sprintf(str, msg_text_shadows ? "ON" : "OFF");
@@ -1511,9 +1511,9 @@ static boolean M_ID_B_Intensity (int choice)
 
 static boolean M_ID_Messages (int choice)
 {
-    showMessages ^= 1;
+    msg_show ^= 1;
     CT_SetMessage(&players[consoleplayer],
-                 DEH_String(showMessages ? "MESSAGES ON" : "MESSAGES OFF"), true);
+                 DEH_String(msg_show ? "MESSAGES ON" : "MESSAGES OFF"), true);
     S_StartSound(NULL, sfx_switch);
     return true;
 }
@@ -1599,10 +1599,10 @@ static void M_Draw_ID_Sound (void)
                M_Item_Glow(9, snd_pitchshift ? GLOW_GREEN : GLOW_RED));
 
     // Number of SFX to mix
-    sprintf(str, "%i", snd_Channels);
+    sprintf(str, "%i", snd_channels);
     MN_DrTextA(str, M_ItemRightAlign(str), 120,
-               M_Item_Glow(10, snd_Channels == 8 ? GLOW_DARKRED :
-                               snd_Channels  < 3 ? GLOW_RED : GLOW_YELLOW));
+               M_Item_Glow(10, snd_channels == 8 ? GLOW_DARKRED :
+                               snd_channels  < 3 ? GLOW_RED : GLOW_YELLOW));
 
     // Mute inactive window
     sprintf(str, snd_mute_inactive ? "ON" : "OFF");
@@ -1708,12 +1708,12 @@ static boolean M_ID_SFXChannels (int option)
     switch (option)
     {
         case 0:
-            if (snd_Channels > 2)
-                snd_Channels--;
+            if (snd_channels > 2)
+                snd_channels--;
             break;
         case 1:
-            if (snd_Channels < 16)
-                snd_Channels++;
+            if (snd_channels < 16)
+                snd_channels++;
         default:
             break;
     }
@@ -4165,7 +4165,7 @@ static void M_ID_ApplyResetHook (void)
     vid_r_intensity = 1.000000;
     vid_g_intensity = 1.000000;
     vid_b_intensity = 1.000000;
-    showMessages = 1;
+    msg_show = 1;
     msg_text_shadows = 0;
     msg_local_time = 0;
 
@@ -4174,7 +4174,7 @@ static void M_ID_ApplyResetHook (void)
     snd_MusicVolume = 10;
     snd_monosfx = 0;
     snd_pitchshift = 1;
-    snd_Channels = 8;
+    snd_channels = 8;
     snd_mute_inactive = 0;
 
     // Widgets
@@ -4904,7 +4904,7 @@ static void DrawFileSlots(Menu_t * menu)
 
 static void DrawOptionsMenu(void)
 {
-    if (showMessages)
+    if (msg_show)
     {
         MN_DrTextB(DEH_String("ON"), 196, 50);
     }

--- a/src/heretic/s_sound.c
+++ b/src/heretic/s_sound.c
@@ -57,7 +57,6 @@ int idmusnum;
 
 int snd_MaxVolume = 10;
 int snd_MusicVolume = 10;
-int snd_Channels = 16;
 
 int AmbChan;
 
@@ -76,14 +75,14 @@ void S_Start(void)
     }
 
     //stop all sounds
-    for (i = 0; i < snd_Channels; i++)
+    for (i = 0; i < snd_channels; i++)
     {
         if (channel[i].handle)
         {
             S_StopSound(channel[i].mo);
         }
     }
-    memset(channel, 0, snd_Channels * sizeof(channel_t));
+    memset(channel, 0, snd_channels * sizeof(channel_t));
 }
 
 void S_StartSong(int song, boolean loop)
@@ -218,11 +217,11 @@ void S_StartSound(void *_origin, int sound_id)
     {
         return;                 // other sounds have greater priority
     }
-    for (i = 0; i < snd_Channels; i++)
+    for (i = 0; i < snd_channels; i++)
     {
         if (origin->player)
         {
-            i = snd_Channels;
+            i = snd_channels;
             break;              // let the player have more than one sound.
         }
         if (origin == channel[i].mo)
@@ -231,7 +230,7 @@ void S_StartSound(void *_origin, int sound_id)
             break;
         }
     }
-    if (i >= snd_Channels)
+    if (i >= snd_channels)
     {
         if (sound_id >= sfx_wind)
         {
@@ -245,24 +244,24 @@ void S_StartSound(void *_origin, int sound_id)
                 AmbChan = -1;
             }
         }
-        for (i = 0; i < snd_Channels; i++)
+        for (i = 0; i < snd_channels; i++)
         {
             if (channel[i].mo == NULL)
             {
                 break;
             }
         }
-        if (i >= snd_Channels)
+        if (i >= snd_channels)
         {
             //look for a lower priority sound to replace.
             sndcount++;
-            if (sndcount >= snd_Channels)
+            if (sndcount >= snd_channels)
             {
                 sndcount = 0;
             }
-            for (chan = 0; chan < snd_Channels; chan++)
+            for (chan = 0; chan < snd_channels; chan++)
             {
-                i = (sndcount + chan) % snd_Channels;
+                i = (sndcount + chan) % snd_channels;
                 if (priority >= channel[i].priority)
                 {
                     chan = -1;  //denote that sound should be replaced.
@@ -407,7 +406,7 @@ void S_StartSoundAmbient (void *_origin, int sound_id)
     vol = soundCurve[dist];
     
     // [JN] No priority checking.
-    for (i = 0; i < snd_Channels; i++)
+    for (i = 0; i < snd_channels; i++)
     {
         if (channel[i].mo == NULL)
         {
@@ -415,7 +414,7 @@ void S_StartSoundAmbient (void *_origin, int sound_id)
         }
     }
 
-    if (i >= snd_Channels)
+    if (i >= snd_channels)
     {
         return;
     }
@@ -463,14 +462,14 @@ void S_StartSoundAtVolume(void *_origin, int sound_id, int volume)
     volume = (volume * (snd_MaxVolume + 1) * 8) >> 7;
 
 // no priority checking, as ambient sounds would be the LOWEST.
-    for (i = 0; i < snd_Channels; i++)
+    for (i = 0; i < snd_channels; i++)
     {
         if (channel[i].mo == NULL)
         {
             break;
         }
     }
-    if (i >= snd_Channels)
+    if (i >= snd_channels)
     {
         return;
     }
@@ -506,7 +505,7 @@ boolean S_StopSoundID(int sound_id, int priority)
     }
     lp = -1;                    //denote the argument sound_id
     found = 0;
-    for (i = 0; i < snd_Channels; i++)
+    for (i = 0; i < snd_channels; i++)
     {
         if (channel[i].sound_id == sound_id && channel[i].mo)
         {
@@ -546,7 +545,7 @@ void S_StopSound(void *_origin)
     mobj_t *origin = _origin;
     int i;
 
-    for (i = 0; i < snd_Channels; i++)
+    for (i = 0; i < snd_channels; i++)
     {
         if (channel[i].mo == origin)
         {
@@ -569,7 +568,7 @@ void S_SoundLink(mobj_t * oldactor, mobj_t * newactor)
 {
     int i;
 
-    for (i = 0; i < snd_Channels; i++)
+    for (i = 0; i < snd_channels; i++)
     {
         if (channel[i].mo == oldactor)
             channel[i].mo = newactor;
@@ -604,7 +603,7 @@ void S_UpdateSounds(mobj_t * listener)
         return;
     }
 
-    for (i = 0; i < snd_Channels; i++)
+    for (i = 0; i < snd_channels; i++)
     {
         if (!channel[i].handle || S_sfx[channel[i].sound_id].usefulness == -1)
         {
@@ -685,9 +684,9 @@ void S_Init(void)
 
     I_SetOPLDriverVer(opl_doom2_1_666);
     soundCurve = Z_Malloc(MAX_SND_DIST, PU_STATIC, NULL);
-    if (snd_Channels > 16)
+    if (snd_channels > 16)
     {
-        snd_Channels = 16;
+        snd_channels = 16;
     }
     I_SetMusicVolume(snd_MusicVolume * 8);
     S_SetMaxVolume(true);
@@ -708,10 +707,10 @@ void S_GetChannelInfo(SoundInfo_t * s)
     int i;
     ChanInfo_t *c;
 
-    s->channelCount = snd_Channels;
+    s->channelCount = snd_channels;
     s->musicVolume = snd_MusicVolume;
     s->soundVolume = snd_MaxVolume;
-    for (i = 0; i < snd_Channels; i++)
+    for (i = 0; i < snd_channels; i++)
     {
         c = &s->chan[i];
         c->id = channel[i].sound_id;
@@ -786,14 +785,14 @@ void S_MuteUnmuteSound (boolean mute)
     if (mute)
     {
         // Stop all sounds and clear sfx channels.
-        for (int i = 0 ; i < snd_Channels ; i++)
+        for (int i = 0 ; i < snd_channels ; i++)
         {
             if (channel[i].handle)
             {
                 S_StopSound(channel[i].mo);
             }
         }
-        memset(channel, 0, snd_Channels * sizeof(channel_t));
+        memset(channel, 0, snd_channels * sizeof(channel_t));
 
         // Set volume to zero.
         I_SetMusicVolume(0);

--- a/src/heretic/s_sound.h
+++ b/src/heretic/s_sound.h
@@ -22,7 +22,6 @@
 
 extern int snd_MaxVolume;
 extern int snd_MusicVolume;
-extern int snd_Channels;
 
 extern int idmusnum;
 

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -87,6 +87,9 @@ static boolean text_input_enabled = true;
 // Bit mask of mouse button state.
 static unsigned int mouse_button_state = 0;
 
+// [JN] Defauld mouse sensivity.
+int mouseSensitivity = 5;
+
 // Disallow mouse and joystick movement to cause forward/backward
 // motion.  Specified with the '-mouse_novert' command line parameter.
 // This is an int to allow saving to config file
@@ -511,6 +514,7 @@ void I_ReadMouse(void)
 // Bind all variables controlling input options.
 void I_BindInputVariables(void)
 {
+    M_BindIntVariable("mouse_sensitivity",         &mouseSensitivity);
     M_BindFloatVariable("mouse_acceleration",      &mouse_acceleration);
     M_BindIntVariable("mouse_threshold",           &mouse_threshold);
     M_BindIntVariable("vanilla_keyboard_mapping",  &vanilla_keyboard_mapping);

--- a/src/i_input.h
+++ b/src/i_input.h
@@ -28,6 +28,7 @@
 
 #define MAX_MOUSE_BUTTONS 8
 
+extern int mouse_sensitivity;
 extern float mouse_acceleration;
 extern int mouse_threshold;
 extern int mouse_y_invert; // [crispy]

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -53,6 +53,9 @@
 #include "id_vars.h"
 
 
+static int vid_startup_delay = 35;
+static int vid_resize_delay = 35;
+
 int SCREENWIDTH, SCREENHEIGHT, SCREENHEIGHT_4_3;
 int NONWIDEWIDTH; // [crispy] non-widescreen SCREENWIDTH
 int WIDESCREENDELTA; // [crispy] horizontal widescreen offset
@@ -164,7 +167,6 @@ int vid_fullscreen = true;
 // Aspect ratio correction mode
 
 int vid_aspect_ratio_correct = true;
-int vid_smooth_scaling = 0;
 static int actualheight;
 
 // Force integer scales for resolution-independent rendering
@@ -1972,11 +1974,11 @@ void I_ToggleVsync (void)
 // file system.
 void I_BindVideoVariables(void)
 {
-    M_BindIntVariable("mouse_enable",                  &usemouse);
+    M_BindIntVariable("vid_startup_delay",             &vid_startup_delay);
+    M_BindIntVariable("vid_resize_delay",              &vid_resize_delay);
     M_BindIntVariable("vid_fullscreen",                &vid_fullscreen);
     M_BindIntVariable("vid_video_display",             &vid_video_display);
     M_BindIntVariable("vid_aspect_ratio_correct",      &vid_aspect_ratio_correct);
-    M_BindIntVariable("vid_smooth_scaling",            &vid_smooth_scaling);
     M_BindIntVariable("vid_integer_scaling",           &vid_integer_scaling);
     M_BindIntVariable("vid_vga_porch_flash",           &vid_vga_porch_flash);
     M_BindIntVariable("vid_fullscreen_width",          &vid_fullscreen_width);
@@ -1986,11 +1988,12 @@ void I_BindVideoVariables(void)
     M_BindIntVariable("vid_max_scaling_buffer_pixels", &vid_max_scaling_buffer_pixels);
     M_BindIntVariable("vid_window_width",              &vid_window_width);
     M_BindIntVariable("vid_window_height",             &vid_window_height);
-    M_BindIntVariable("mouse_grab",                    &mouse_grab);
     M_BindStringVariable("vid_video_driver",           &vid_video_driver);
     M_BindStringVariable("vid_screen_scale_api",       &vid_screen_scale_api);
     M_BindIntVariable("vid_window_position_x",         &vid_window_position_x);
     M_BindIntVariable("vid_window_position_y",         &vid_window_position_y);
+    M_BindIntVariable("mouse_enable",                  &usemouse);
+    M_BindIntVariable("mouse_grab",                    &mouse_grab);
 }
 #ifdef CRISPY_TRUECOLOR
 const pixel_t I_BlendAdd (const pixel_t bg, const pixel_t fg)

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -956,7 +956,7 @@ void I_FinishUpdate (void)
 	}
 
     // Draw disk icon before blit, if necessary.
-    if (vid_diskicon && vid_diskicon_enabled)
+    if (vid_diskicon && diskicon_enabled)
     {
         V_DrawDiskIcon();
     }

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -956,7 +956,7 @@ void I_FinishUpdate (void)
 	}
 
     // Draw disk icon before blit, if necessary.
-    if (vid_diskicon)
+    if (vid_diskicon && vid_diskicon_enabled)
     {
         V_DrawDiskIcon();
     }

--- a/src/id_vars.c
+++ b/src/id_vars.c
@@ -20,66 +20,81 @@
 #include "m_config.h"  // [JN] M_BindIntVariable
 
 
+// Game modes
+int crl_spectating = 0;  // RestlessRodent -- CRL
+int crl_freeze = 0;
+
+
 // -----------------------------------------------------------------------------
 // [JN] ID-specific config variables.
 // -----------------------------------------------------------------------------
 
-// System and video
+//
+// Video options
+//
+
 #ifdef CRISPY_TRUECOLOR
 int vid_truecolor = 0;
 #endif
 int vid_resolution = 2;
 int vid_widescreen = 0;
-int vid_startup_delay = 35;
-int vid_resize_delay = 35;
 int vid_uncapped_fps = 0;
 int vid_fpslimit = 60;
 int vid_vsync = 1;
 int vid_showfps = 0;
-
+int vid_smooth_scaling = 0;
+// Miscellaneous
+int vid_screenwipe = 1;
 int vid_diskicon = 1;
-int vid_diskicon_off = 0;
 int vid_endoom = 0;
 
+//
+// Display options
+//
+
+int dp_screen_size = 10;
+int dp_detail_level = 0;  // Blocky mode (0 = high, 1 = normal)
 int vid_gamma = 10;
 int vid_fov = 90;
+int dp_menu_shading = 0;
+int dp_level_brightness = 0;
+// Color settings
 int vid_saturation = 100;
 float vid_r_intensity = 1.000000;
 float vid_g_intensity = 1.000000;
 float vid_b_intensity = 1.000000;
-int dp_screen_size = 10;
-int vid_screenwipe = 1;
-int msg_text_shadows = 0;
-
-// Display
-int dp_detail_level = 0;  // Blocky mode (0 = high, 1 = normal)
-int dp_menu_shading = 0;
-int dp_level_brightness = 0;
-
-// Messages
+// Messages Settings
 int msg_show = 1;
 int msg_alignment = 0;
+int msg_text_shadows = 0;
 int msg_local_time = 0;
 
-// Game modes
-int crl_spectating = 0;
-int crl_freeze = 0;
+//
+// Sound options
+//
 
-// Widgets
-int widget_location = 0;
-int widget_coords = 0;
-int widget_render = 0;
-int widget_kis = 0;
-int widget_time = 0;
-int widget_totaltime = 0;
-int widget_levelname = 0;
-int widget_health = 0;
-
-// Sound
 int snd_monosfx = 0;
 int snd_channels = 8;
 int snd_mute_inactive = 0;
 
+//
+// Control settings
+//
+
+int mouse_look = 0;
+
+//
+// Widgets and automap
+//
+
+int widget_location = 0;
+int widget_kis = 0;
+int widget_time = 0;
+int widget_totaltime = 0;
+int widget_levelname = 0;
+int widget_coords = 0;
+int widget_render = 0;
+int widget_health = 0;
 // Automap
 int automap_scheme = 0;
 int automap_smooth = 0;
@@ -88,7 +103,11 @@ int automap_rotate = 0;
 int automap_overlay = 0;
 int automap_shading = 0;
 
+//
 // Gameplay features
+//
+
+// Visual
 int vis_brightmaps = 0;
 int vis_translucency = 0;
 int vis_fake_contrast = 1;
@@ -100,27 +119,32 @@ int vis_invul_sky = 0;
 int vis_linear_sky = 0;
 int vis_flip_corpses = 0;
 
+// Crosshair
 int xhair_draw = 0;
 int xhair_color = 0;
 
+// Status bar
 int st_colored_stbar = 0;
 int st_negative_health = 0;
 int st_blinking_keys = 0;
-int st_ammo_widget = 0;  // Heretic only
+int st_ammo_widget = 0;
 
+// Audible
 int aud_z_axis_sfx = 0;
 int aud_full_sounds = 0;
 int aud_exit_sounds = 0;
 
+// Physical
 int phys_torque = 0;
 int phys_ssg_tear_monsters = 0;
 int phys_toss_drop = 0;
 int phys_floating_powerups = 0;
 int phys_weapon_alignment = 0;
+int phys_breathing = 0;
 
+// Gameplay
 int gp_default_skill = 2;
 int gp_revealed_secrets = 0;
-int phys_breathing = 0;
 int gp_flip_levels = 0;
 
 // Demos
@@ -134,8 +158,6 @@ int compat_pistol_start = 0;
 int compat_blockmap_fix = 0;
 int compat_vertical_aiming = 0;
 
-// Mouse look
-int mouse_look = 0;
 
 // -----------------------------------------------------------------------------
 // [JN] ID-specific config variables binding functions.
@@ -143,69 +165,84 @@ int mouse_look = 0;
 
 void ID_BindVariables (GameMission_t mission)
 {
-    // Video
+    //
+    // Video options
+    //
+
 #ifdef CRISPY_TRUECOLOR
     M_BindIntVariable("vid_truecolor",                  &vid_truecolor);
 #endif
     M_BindIntVariable("vid_resolution",                 &vid_resolution);
     M_BindIntVariable("vid_widescreen",                 &vid_widescreen);
-    M_BindIntVariable("vid_startup_delay",              &vid_startup_delay);
-    M_BindIntVariable("vid_resize_delay",               &vid_resize_delay);
     M_BindIntVariable("vid_uncapped_fps",               &vid_uncapped_fps);
     M_BindIntVariable("vid_fpslimit",                   &vid_fpslimit);
     M_BindIntVariable("vid_vsync",                      &vid_vsync);
     M_BindIntVariable("vid_showfps",                    &vid_showfps);
-    M_BindIntVariable("vid_gamma",                      &vid_gamma);
-    
+    M_BindIntVariable("vid_smooth_scaling",             &vid_smooth_scaling);
+    // Miscellaneous
     if (mission == doom)
     {
+        M_BindIntVariable("vid_screenwipe",             &vid_screenwipe);
         M_BindIntVariable("vid_diskicon",               &vid_diskicon);
     }
     M_BindIntVariable("vid_endoom",                     &vid_endoom);
-    
+
+    //
+    // Display options
+    //
+
+    M_BindIntVariable("dp_screen_size",                 &dp_screen_size);
+    M_BindIntVariable("dp_detail_level",                &dp_detail_level);
+    M_BindIntVariable("vid_gamma",                      &vid_gamma);
     M_BindIntVariable("vid_fov",                        &vid_fov);
+    M_BindIntVariable("dp_menu_shading",                &dp_menu_shading);
+    M_BindIntVariable("dp_level_brightness",            &dp_level_brightness);
+    // Color settings
     M_BindIntVariable("vid_saturation",                 &vid_saturation);
     M_BindFloatVariable("vid_r_intensity",              &vid_r_intensity);
     M_BindFloatVariable("vid_g_intensity",              &vid_g_intensity);
     M_BindFloatVariable("vid_b_intensity",              &vid_b_intensity);
-    M_BindIntVariable("vid_screenwipe",                 &vid_screenwipe);
-
-    // Display
-    M_BindIntVariable("dp_screen_size",                 &dp_screen_size);
-    M_BindIntVariable("dp_detail_level",                &dp_detail_level);
-    M_BindIntVariable("dp_menu_shading",                &dp_menu_shading);
-    M_BindIntVariable("dp_level_brightness",            &dp_level_brightness);
-
-    // Messages
+    // Messages Settings
     M_BindIntVariable("msg_show",                       &msg_show);
+    if (mission == doom)
+    {
+        M_BindIntVariable("msg_alignment",              &msg_alignment);
+    }
     M_BindIntVariable("msg_text_shadows",               &msg_text_shadows);
-    M_BindIntVariable("msg_alignment",                  &msg_alignment);
-    M_BindIntVariable("msg_local_time",                 &msg_local_time);
+    M_BindIntVariable("msg_local_time",                 &msg_local_time);    
 
-    // Sound
+    //
+    // Sound options
+    //
+
     M_BindIntVariable("snd_monosfx",                    &snd_monosfx);
     M_BindIntVariable("snd_channels",                   &snd_channels);
     M_BindIntVariable("snd_mute_inactive",              &snd_mute_inactive);
 
-    // Control
+    //
+    // Control settings
+    //
+
     M_BindIntVariable("mouse_look",                     &mouse_look);
 
-    // Widgets
+    //
+    // Widgets and automap
+    //
+
     M_BindIntVariable("widget_location",                &widget_location);
-    M_BindIntVariable("widget_coords",                  &widget_coords);
-    M_BindIntVariable("widget_render",                  &widget_render);
     M_BindIntVariable("widget_kis",                     &widget_kis);
     M_BindIntVariable("widget_time",                    &widget_time);
     M_BindIntVariable("widget_totaltime",               &widget_totaltime);
     M_BindIntVariable("widget_levelname",               &widget_levelname);
+    M_BindIntVariable("widget_coords",                  &widget_coords);
+    M_BindIntVariable("widget_render",                  &widget_render);
     M_BindIntVariable("widget_health",                  &widget_health);
-
     // Automap
     if (mission == doom)
     {
         M_BindIntVariable("automap_scheme",             &automap_scheme);
+        M_BindIntVariable("automap_smooth",             &automap_smooth);
     }
-    M_BindIntVariable("automap_smooth",                 &automap_smooth);
     M_BindIntVariable("automap_secrets",                &automap_secrets);
     M_BindIntVariable("automap_rotate",                 &automap_rotate);
     M_BindIntVariable("automap_overlay",                &automap_overlay);
@@ -220,8 +257,11 @@ void ID_BindVariables (GameMission_t mission)
     M_BindIntVariable("vis_translucency",               &vis_translucency);
     M_BindIntVariable("vis_fake_contrast",              &vis_fake_contrast);
     M_BindIntVariable("vis_smooth_light",               &vis_smooth_light);
-    M_BindIntVariable("vis_improved_fuzz",              &vis_improved_fuzz);
-    M_BindIntVariable("vis_colored_blood",              &vis_colored_blood);
+    if (mission == doom)
+    {
+        M_BindIntVariable("vis_improved_fuzz",          &vis_improved_fuzz);
+        M_BindIntVariable("vis_colored_blood",          &vis_colored_blood);
+    }
     M_BindIntVariable("vis_swirling_liquids",           &vis_swirling_liquids);
     M_BindIntVariable("vis_invul_sky",                  &vis_invul_sky);
     M_BindIntVariable("vis_linear_sky",                 &vis_linear_sky);
@@ -233,9 +273,9 @@ void ID_BindVariables (GameMission_t mission)
     
     // Status bar
     M_BindIntVariable("st_colored_stbar",               &st_colored_stbar);
-    M_BindIntVariable("st_negative_health",             &st_negative_health);
     if (mission == doom)
     {
+        M_BindIntVariable("st_negative_health",         &st_negative_health);
         M_BindIntVariable("st_blinking_keys",           &st_blinking_keys);
     }
     if (mission == heretic)
@@ -245,17 +285,20 @@ void ID_BindVariables (GameMission_t mission)
     
     // Audible
     M_BindIntVariable("aud_z_axis_sfx",                 &aud_z_axis_sfx);
-    M_BindIntVariable("aud_full_sounds",                &aud_full_sounds);
     if (mission == doom)
     {
+        M_BindIntVariable("aud_full_sounds",            &aud_full_sounds);
         M_BindIntVariable("aud_exit_sounds",            &aud_exit_sounds);
     }
     
     // Physical
     M_BindIntVariable("phys_torque",                    &phys_torque);
-    M_BindIntVariable("phys_ssg_tear_monsters",         &phys_ssg_tear_monsters);
-    M_BindIntVariable("phys_toss_drop",                 &phys_toss_drop);
-    M_BindIntVariable("phys_floating_powerups",         &phys_floating_powerups);
+    if (mission == doom)
+    {
+        M_BindIntVariable("phys_ssg_tear_monsters",     &phys_ssg_tear_monsters);
+        M_BindIntVariable("phys_toss_drop",             &phys_toss_drop);
+        M_BindIntVariable("phys_floating_powerups",     &phys_floating_powerups);
+    }
     M_BindIntVariable("phys_weapon_alignment",          &phys_weapon_alignment);
     M_BindIntVariable("phys_breathing",                 &phys_breathing);
     
@@ -273,5 +316,8 @@ void ID_BindVariables (GameMission_t mission)
     // Compatibility-breaking
     M_BindIntVariable("compat_pistol_start",            &compat_pistol_start);
     M_BindIntVariable("compat_blockmap_fix",            &compat_blockmap_fix);
-    M_BindIntVariable("compat_vertical_aiming",         &compat_vertical_aiming);
+    if (mission == doom)
+    {
+        M_BindIntVariable("compat_vertical_aiming",     &compat_vertical_aiming);
+    }
 }

--- a/src/id_vars.c
+++ b/src/id_vars.c
@@ -16,6 +16,7 @@
 //
 
 
+#include "id_vars.h"  // [JN] M_BindIntVariable
 #include "m_config.h"  // [JN] M_BindIntVariable
 
 
@@ -29,13 +30,17 @@ int vid_truecolor = 0;
 #endif
 int vid_resolution = 2;
 int vid_widescreen = 0;
-
 int vid_startup_delay = 35;
 int vid_resize_delay = 35;
 int vid_uncapped_fps = 0;
 int vid_fpslimit = 60;
 int vid_vsync = 1;
 int vid_showfps = 0;
+
+int vid_diskicon = 1;
+int vid_diskicon_off = 0;
+int vid_endoom = 0;
+
 int vid_gamma = 10;
 int vid_fov = 90;
 int vid_saturation = 100;
@@ -47,10 +52,12 @@ int vid_screenwipe = 1;
 int msg_text_shadows = 0;
 
 // Display
+int dp_detail_level = 0;  // Blocky mode (0 = high, 1 = normal)
 int dp_menu_shading = 0;
 int dp_level_brightness = 0;
 
 // Messages
+int msg_show = 1;
 int msg_alignment = 0;
 int msg_local_time = 0;
 
@@ -70,6 +77,7 @@ int widget_health = 0;
 
 // Sound
 int snd_monosfx = 0;
+int snd_channels = 8;
 int snd_mute_inactive = 0;
 
 // Automap
@@ -130,18 +138,17 @@ int compat_vertical_aiming = 0;
 int mouse_look = 0;
 
 // -----------------------------------------------------------------------------
-// [JN] ID-specific config variables binding function.
+// [JN] ID-specific config variables binding functions.
 // -----------------------------------------------------------------------------
 
-void ID_BindVariables (void)
+void ID_BindVariables (GameMission_t mission)
 {
-    // System and video
+    // Video
 #ifdef CRISPY_TRUECOLOR
     M_BindIntVariable("vid_truecolor",                  &vid_truecolor);
 #endif
     M_BindIntVariable("vid_resolution",                 &vid_resolution);
     M_BindIntVariable("vid_widescreen",                 &vid_widescreen);
-    
     M_BindIntVariable("vid_startup_delay",              &vid_startup_delay);
     M_BindIntVariable("vid_resize_delay",               &vid_resize_delay);
     M_BindIntVariable("vid_uncapped_fps",               &vid_uncapped_fps);
@@ -149,22 +156,39 @@ void ID_BindVariables (void)
     M_BindIntVariable("vid_vsync",                      &vid_vsync);
     M_BindIntVariable("vid_showfps",                    &vid_showfps);
     M_BindIntVariable("vid_gamma",                      &vid_gamma);
+    
+    if (mission == doom)
+    {
+        M_BindIntVariable("vid_diskicon",               &vid_diskicon);
+    }
+    M_BindIntVariable("vid_endoom",                     &vid_endoom);
+    
     M_BindIntVariable("vid_fov",                        &vid_fov);
     M_BindIntVariable("vid_saturation",                 &vid_saturation);
     M_BindFloatVariable("vid_r_intensity",              &vid_r_intensity);
     M_BindFloatVariable("vid_g_intensity",              &vid_g_intensity);
     M_BindFloatVariable("vid_b_intensity",              &vid_b_intensity);
-    M_BindIntVariable("dp_screen_size",                 &dp_screen_size);
     M_BindIntVariable("vid_screenwipe",                 &vid_screenwipe);
-    M_BindIntVariable("msg_text_shadows",               &msg_text_shadows);
 
     // Display
+    M_BindIntVariable("dp_screen_size",                 &dp_screen_size);
+    M_BindIntVariable("dp_detail_level",                &dp_detail_level);
     M_BindIntVariable("dp_menu_shading",                &dp_menu_shading);
     M_BindIntVariable("dp_level_brightness",            &dp_level_brightness);
 
     // Messages
+    M_BindIntVariable("msg_show",                       &msg_show);
+    M_BindIntVariable("msg_text_shadows",               &msg_text_shadows);
     M_BindIntVariable("msg_alignment",                  &msg_alignment);
     M_BindIntVariable("msg_local_time",                 &msg_local_time);
+
+    // Sound
+    M_BindIntVariable("snd_monosfx",                    &snd_monosfx);
+    M_BindIntVariable("snd_channels",                   &snd_channels);
+    M_BindIntVariable("snd_mute_inactive",              &snd_mute_inactive);
+
+    // Control
+    M_BindIntVariable("mouse_look",                     &mouse_look);
 
     // Widgets
     M_BindIntVariable("widget_location",                &widget_location);
@@ -176,19 +200,22 @@ void ID_BindVariables (void)
     M_BindIntVariable("widget_levelname",               &widget_levelname);
     M_BindIntVariable("widget_health",                  &widget_health);
 
-    // Sound
-    M_BindIntVariable("snd_monosfx",                    &snd_monosfx);
-    M_BindIntVariable("snd_mute_inactive",              &snd_mute_inactive);
-
     // Automap
-    M_BindIntVariable("automap_scheme",                 &automap_scheme);
+    if (mission == doom)
+    {
+        M_BindIntVariable("automap_scheme",             &automap_scheme);
+    }
     M_BindIntVariable("automap_smooth",                 &automap_smooth);
     M_BindIntVariable("automap_secrets",                &automap_secrets);
     M_BindIntVariable("automap_rotate",                 &automap_rotate);
     M_BindIntVariable("automap_overlay",                &automap_overlay);
     M_BindIntVariable("automap_shading",                &automap_shading);
 
+    //
     // Gameplay features
+    //
+
+    // Visual
     M_BindIntVariable("vis_brightmaps",                 &vis_brightmaps);
     M_BindIntVariable("vis_translucency",               &vis_translucency);
     M_BindIntVariable("vis_fake_contrast",              &vis_fake_contrast);
@@ -199,40 +226,52 @@ void ID_BindVariables (void)
     M_BindIntVariable("vis_invul_sky",                  &vis_invul_sky);
     M_BindIntVariable("vis_linear_sky",                 &vis_linear_sky);
     M_BindIntVariable("vis_flip_corpses",               &vis_flip_corpses);
-
+    
+    // Crosshair
     M_BindIntVariable("xhair_draw",                     &xhair_draw);
     M_BindIntVariable("xhair_color",                    &xhair_color);
-
+    
+    // Status bar
     M_BindIntVariable("st_colored_stbar",               &st_colored_stbar);
     M_BindIntVariable("st_negative_health",             &st_negative_health);
-    M_BindIntVariable("st_blinking_keys",               &st_blinking_keys);
-
+    if (mission == doom)
+    {
+        M_BindIntVariable("st_blinking_keys",           &st_blinking_keys);
+    }
+    if (mission == heretic)
+    {
+        M_BindIntVariable("st_ammo_widget",             &st_ammo_widget);
+    }
+    
+    // Audible
     M_BindIntVariable("aud_z_axis_sfx",                 &aud_z_axis_sfx);
     M_BindIntVariable("aud_full_sounds",                &aud_full_sounds);
-    M_BindIntVariable("aud_exit_sounds",                &aud_exit_sounds);
-
+    if (mission == doom)
+    {
+        M_BindIntVariable("aud_exit_sounds",            &aud_exit_sounds);
+    }
+    
+    // Physical
     M_BindIntVariable("phys_torque",                    &phys_torque);
     M_BindIntVariable("phys_ssg_tear_monsters",         &phys_ssg_tear_monsters);
     M_BindIntVariable("phys_toss_drop",                 &phys_toss_drop);
     M_BindIntVariable("phys_floating_powerups",         &phys_floating_powerups);
     M_BindIntVariable("phys_weapon_alignment",          &phys_weapon_alignment);
-
+    M_BindIntVariable("phys_breathing",                 &phys_breathing);
+    
+    // Gameplay
     M_BindIntVariable("gp_default_skill",               &gp_default_skill);
     M_BindIntVariable("gp_revealed_secrets",            &gp_revealed_secrets);
-    M_BindIntVariable("phys_breathing",                 &phys_breathing);
     M_BindIntVariable("gp_flip_levels",                 &gp_flip_levels);
-
+    
     // Demos
     M_BindIntVariable("demo_timer",                     &demo_timer);
     M_BindIntVariable("demo_timerdir",                  &demo_timerdir);
     M_BindIntVariable("demo_bar",                       &demo_bar);
     M_BindIntVariable("demo_internal",                  &demo_internal);
-
+    
     // Compatibility-breaking
     M_BindIntVariable("compat_pistol_start",            &compat_pistol_start);
     M_BindIntVariable("compat_blockmap_fix",            &compat_blockmap_fix);
     M_BindIntVariable("compat_vertical_aiming",         &compat_vertical_aiming);
-
-    // Mouse look
-    M_BindIntVariable("mouse_look",                     &mouse_look);
 }

--- a/src/id_vars.c
+++ b/src/id_vars.c
@@ -16,7 +16,7 @@
 //
 
 
-#include "id_vars.h"  // [JN] M_BindIntVariable
+#include "id_vars.h"
 #include "m_config.h"  // [JN] M_BindIntVariable
 
 

--- a/src/id_vars.h
+++ b/src/id_vars.h
@@ -16,6 +16,9 @@
 //
 
 
+#include "d_mode.h"  // [JN] M_BindIntVariable
+
+
 #pragma once
 
 
@@ -29,6 +32,7 @@ extern int vid_truecolor;
 #endif
 extern int vid_resolution;
 extern int vid_widescreen;
+
 extern int vid_diskicon;
 extern int vid_endoom;
 
@@ -49,10 +53,12 @@ extern int vid_screenwipe;
 extern int msg_text_shadows;
 
 // Display
+extern int dp_detail_level;
 extern int dp_menu_shading;
 extern int dp_level_brightness;
 
 // Messages
+extern int msg_show;
 extern int msg_alignment;
 extern int msg_local_time;
 
@@ -72,6 +78,7 @@ extern int widget_health;
 
 // Sound
 extern int snd_monosfx;
+extern int snd_channels;
 extern int snd_mute_inactive;
 
 // Automap
@@ -131,4 +138,4 @@ extern int compat_vertical_aiming;
 // Mouse look
 extern int mouse_look;
 
-extern void ID_BindVariables (void);
+extern void ID_BindVariables (GameMission_t mission);

--- a/src/id_vars.h
+++ b/src/id_vars.h
@@ -36,8 +36,6 @@ extern int vid_widescreen;
 extern int vid_diskicon;
 extern int vid_endoom;
 
-extern int vid_startup_delay;
-extern int vid_resize_delay;
 extern int vid_uncapped_fps;
 extern int vid_fpslimit;
 extern int vid_vsync;

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -341,8 +341,6 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_KEY(key_pause),
     CONFIG_VARIABLE_KEY(key_menu_screenshot),
     CONFIG_VARIABLE_KEY(key_message_refresh),
-    // [JN] Heretic using ENTER for afrtifacts activation.
-    CONFIG_VARIABLE_KEY(key_message_refresh_hr),
     CONFIG_VARIABLE_KEY(key_demo_quit),
 
     // Multiplayer

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -144,7 +144,6 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_INT(vid_window_position_y),
     CONFIG_VARIABLE_INT(vid_video_display),
     CONFIG_VARIABLE_INT(vid_aspect_ratio_correct),
-    CONFIG_VARIABLE_INT(vid_smooth_scaling),
     CONFIG_VARIABLE_INT(vid_integer_scaling),
     CONFIG_VARIABLE_INT(vid_vga_porch_flash),
     CONFIG_VARIABLE_INT(vid_window_width),
@@ -155,7 +154,7 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_INT(vid_force_software_renderer),
     CONFIG_VARIABLE_INT(vid_max_scaling_buffer_pixels),
 
-    // Video
+    // Video options
     CONFIG_VARIABLE_INT(vid_truecolor),
     CONFIG_VARIABLE_INT(vid_resolution),
     CONFIG_VARIABLE_INT(vid_widescreen),
@@ -163,17 +162,18 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_INT(vid_fpslimit),
     CONFIG_VARIABLE_INT(vid_vsync),
     CONFIG_VARIABLE_INT(vid_showfps),
+    CONFIG_VARIABLE_INT(vid_smooth_scaling),
+    CONFIG_VARIABLE_INT(vid_screenwipe),
+    CONFIG_VARIABLE_INT(vid_diskicon),
+    CONFIG_VARIABLE_INT(vid_endoom),
+
+    // Display options
     CONFIG_VARIABLE_INT(vid_gamma),
     CONFIG_VARIABLE_INT(vid_fov),
     CONFIG_VARIABLE_INT(vid_saturation),
     CONFIG_VARIABLE_FLOAT(vid_r_intensity),
     CONFIG_VARIABLE_FLOAT(vid_g_intensity),
     CONFIG_VARIABLE_FLOAT(vid_b_intensity),
-    CONFIG_VARIABLE_INT(vid_screenwipe),
-    CONFIG_VARIABLE_INT(vid_diskicon),
-    CONFIG_VARIABLE_INT(vid_endoom),
-
-    // Display
     CONFIG_VARIABLE_INT(dp_screen_size),
     CONFIG_VARIABLE_INT(dp_detail_level),
     CONFIG_VARIABLE_INT(dp_menu_shading),
@@ -192,15 +192,14 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_INT(sfx_volume),
     CONFIG_VARIABLE_INT(music_volume),
     CONFIG_VARIABLE_INT(snd_sfxdevice),
-    CONFIG_VARIABLE_INT(snd_monosfx),
-    CONFIG_VARIABLE_INT(snd_pitchshift),
-    CONFIG_VARIABLE_INT(snd_channels),
-    CONFIG_VARIABLE_INT(snd_mute_inactive),
     CONFIG_VARIABLE_INT(snd_musicdevice),
     CONFIG_VARIABLE_STRING(snd_musiccmd),
     CONFIG_VARIABLE_STRING(snd_dmxoption),
     CONFIG_VARIABLE_INT_HEX(opl_io_port),
-
+    CONFIG_VARIABLE_INT(snd_monosfx),
+    CONFIG_VARIABLE_INT(snd_pitchshift),
+    CONFIG_VARIABLE_INT(snd_channels),
+    CONFIG_VARIABLE_INT(snd_mute_inactive),
 #ifdef HAVE_FLUIDSYNTH
     CONFIG_VARIABLE_INT(fsynth_chorus_active),
     CONFIG_VARIABLE_FLOAT(fsynth_chorus_depth),
@@ -289,8 +288,8 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_KEY(key_arti_torch),
     CONFIG_VARIABLE_KEY(key_arti_morph),
 
-    // RestlessRodent -- CRL (Special modes)
-    CONFIG_VARIABLE_KEY(key_spectator),
+    // Game modes
+    CONFIG_VARIABLE_KEY(key_spectator),  // RestlessRodent -- CRL
     CONFIG_VARIABLE_KEY(key_freeze),
     CONFIG_VARIABLE_KEY(key_notarget),
     CONFIG_VARIABLE_KEY(key_buddha),
@@ -404,6 +403,9 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_INT(mouseb_invright),
     CONFIG_VARIABLE_INT(mouseb_useartifact),
 
+    // Heretic: permanent "noartiskip" mode
+    CONFIG_VARIABLE_INT(ctrl_noartiskip),
+
     //
     // Joystick controls
     //
@@ -451,9 +453,6 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_INT(joyb_menu_activate),
     CONFIG_VARIABLE_INT(joyb_toggle_automap),
 
-    // Controls
-    CONFIG_VARIABLE_INT(ctrl_noartiskip),
-    
     // Widgets
     CONFIG_VARIABLE_INT(widget_location),
     CONFIG_VARIABLE_INT(widget_kis),
@@ -496,7 +495,7 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_INT(st_colored_stbar),
     CONFIG_VARIABLE_INT(st_negative_health),
     CONFIG_VARIABLE_INT(st_blinking_keys),
-    CONFIG_VARIABLE_INT(st_ammo_widget),  // Heretic only
+    CONFIG_VARIABLE_INT(st_ammo_widget),
 
     // Audible
     CONFIG_VARIABLE_INT(aud_z_axis_sfx),

--- a/src/v_diskicon.c
+++ b/src/v_diskicon.c
@@ -29,7 +29,7 @@
 
 
 // [JN] Should be enabled only for Doom.
-boolean vid_diskicon_enabled;
+boolean diskicon_enabled;
 
 // Only display the disk icon if more then this much bytes have been read
 // during the previous tic.

--- a/src/v_diskicon.c
+++ b/src/v_diskicon.c
@@ -28,6 +28,9 @@
 #include "id_vars.h"
 
 
+// [JN] Should be enabled only for Doom.
+boolean vid_diskicon_enabled;
+
 // Only display the disk icon if more then this much bytes have been read
 // during the previous tic.
 static const int diskicon_threshold = 20*1024;

--- a/src/v_diskicon.h
+++ b/src/v_diskicon.h
@@ -30,4 +30,6 @@ extern void V_BeginRead (size_t nbytes);
 extern void V_DrawDiskIcon (void);
 extern void V_RestoreDiskBackground (void);
 
+extern boolean vid_diskicon_enabled;
+
 #endif

--- a/src/v_diskicon.h
+++ b/src/v_diskicon.h
@@ -30,6 +30,6 @@ extern void V_BeginRead (size_t nbytes);
 extern void V_DrawDiskIcon (void);
 extern void V_RestoreDiskBackground (void);
 
-extern boolean vid_diskicon_enabled;
+extern boolean diskicon_enabled;
 
 #endif


### PR DESCRIPTION
This will unify identical variables for both games and will prevent appearing of Doom binds in Heretic config and vice versa.