### PR TITLE
Heretic: switch to Doom bezel drawing code

### DIFF
--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -690,7 +690,6 @@ void AM_Stop (void)
 {
     automapactive = false;
     stopped = true;
-    BorderNeedRefresh = true;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/heretic/ct_chat.c
+++ b/src/heretic/ct_chat.c
@@ -352,7 +352,6 @@ void CT_Drawer (void)
             }
         }
         V_DrawPatch(x, 10, W_CacheLumpName(DEH_String("FONTA59"), PU_CACHE));
-        BorderTopRefresh = true;
         UpdateState |= I_MESSAGES;
     }
 }
@@ -475,7 +474,6 @@ void CT_SetMessage (player_t *player, const char *message, boolean ultmsg, byte 
     player->message = message;
     player->messageTics = MESSAGETICS;
     player->messageColor = table;
-    BorderTopRefresh = true;
 
     if (ultmsg)
     {
@@ -511,7 +509,6 @@ void MSG_Ticker (void)
     if (!player->messageTics)
     {                           // Refresh the screen when a message goes away
         ultimatemsg = false;    // clear out any chat messages.
-        BorderTopRefresh = true;
     }
     if (player->messageCenteredTics > 0)
     {

--- a/src/heretic/ct_chat.c
+++ b/src/heretic/ct_chat.c
@@ -352,7 +352,6 @@ void CT_Drawer (void)
             }
         }
         V_DrawPatch(x, 10, W_CacheLumpName(DEH_String("FONTA59"), PU_CACHE));
-        UpdateState |= I_MESSAGES;
     }
 }
 

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -165,6 +165,7 @@ static void ID_DrawMessageCentered (void)
 
 void D_Display(void)
 {
+    static gamestate_t oldgamestate = -1;
 
     // For comparative timing / profiling
     if (nodrawers)
@@ -185,6 +186,7 @@ void D_Display(void)
     if (setsizeneeded)
     {
         R_ExecuteSetViewSize();
+        oldgamestate = -1;  // force background redraw
     }
 
 //
@@ -204,10 +206,21 @@ void D_Display(void)
                 return;
             }
 
+            // [JN] See if the border needs to be initially drawn.
+            if (oldgamestate != GS_LEVEL)
+            {
+                R_FillBackScreen();
+            }
+
+            // [JN] See if the border needs to be updated to the screen.
+            if (scaledviewwidth != SCREENWIDTH)
+            {
+                R_DrawViewBorder();
+            }
+
             if (automapactive)
             {
                 AM_Drawer();
-                BorderNeedRefresh = true;
             }
 
             // [JN] Allow to draw level name separately from automap.
@@ -282,6 +295,8 @@ void D_Display(void)
     {
         V_DrawMouseSpeedBox(testcontrols_mousespeed);
     }
+
+    oldgamestate = gamestate;
 
     if (paused && !MenuActive && !askforquit)
     {
@@ -466,7 +481,6 @@ void D_DoAdvanceDemo(void)
             pagename = DEH_String("TITLE");
             break;
         case 2:
-            BorderNeedRefresh = true;
             UpdateState |= I_FULLSCRN;
             if (demo_internal)
             {
@@ -479,7 +493,6 @@ void D_DoAdvanceDemo(void)
             pagename = DEH_String("CREDIT");
             break;
         case 4:
-            BorderNeedRefresh = true;
             UpdateState |= I_FULLSCRN;
             if (demo_internal)
             {
@@ -499,7 +512,6 @@ void D_DoAdvanceDemo(void)
             }
             break;
         case 6:
-            BorderNeedRefresh = true;
             UpdateState |= I_FULLSCRN;
             if (demo_internal)
             {
@@ -1386,7 +1398,6 @@ void D_DoomMain(void)
     if (gameaction != ga_loadgame)
     {
         UpdateState |= I_FULLSCRN;
-        BorderNeedRefresh = true;
         if (autostart || netgame)
         {
             G_InitNew(startskill, startepisode, startmap);

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -165,6 +165,7 @@ static void ID_DrawMessageCentered (void)
 
 void D_Display(void)
 {
+    // [JN] Optimized screen background and beveled edge drawing.
     static gamestate_t oldgamestate = -1;
 
     // For comparative timing / profiling
@@ -186,7 +187,8 @@ void D_Display(void)
     if (setsizeneeded)
     {
         R_ExecuteSetViewSize();
-        oldgamestate = -1;  // force background redraw
+        // Force background redraw
+        oldgamestate = -1;
     }
 
 //

--- a/src/heretic/doomdef.h
+++ b/src/heretic/doomdef.h
@@ -829,7 +829,6 @@ extern int UpdateState;
 #define I_NOUPDATE	0
 #define I_FULLVIEW	1
 #define I_STATBAR	2
-#define I_MESSAGES	4
 #define I_FULLSCRN	8
 
 void R_RenderPlayerView(player_t * player);

--- a/src/heretic/doomdef.h
+++ b/src/heretic/doomdef.h
@@ -824,9 +824,6 @@ void P_UnArchiveAutomap(void);
 
 extern boolean setsizeneeded;
 
-extern boolean BorderNeedRefresh;
-extern boolean BorderTopRefresh;
-
 extern int UpdateState;
 // define the different areas for the dirty map
 #define I_NOUPDATE	0
@@ -842,7 +839,7 @@ void R_Init(void);
 // called by startup code
 
 void R_DrawViewBorder(void);
-void R_DrawTopBorder(void);
+void R_FillBackScreen(void);
 // if the view size is not full screen, draws a border around it
 
 void R_SetViewSize(int blocks, int detail);

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -2258,7 +2258,7 @@ void G_DoLoadGame(void)
         I_Error("Bad savegame");
     }
 
-    // draw the pattern into the back screen
+    // Draw the pattern into the back screen
     R_FillBackScreen();
 }
 
@@ -3177,7 +3177,7 @@ void G_DoSaveGame(void)
 
     free(filename);
 
-    // draw the pattern into the back screen
+    // Draw the pattern into the back screen
     R_FillBackScreen();
 }
 

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -2257,6 +2257,9 @@ void G_DoLoadGame(void)
     {                           // Missing savegame termination marker
         I_Error("Bad savegame");
     }
+
+    // draw the pattern into the back screen
+    R_FillBackScreen();
 }
 
 
@@ -2360,7 +2363,6 @@ void G_InitNew(skill_t skill, int episode, int map)
     gameepisode = episode;
     gamemap = map;
     gameskill = skill;
-    BorderNeedRefresh = true;
 
     // [crispy] CPhipps - total time for all completed levels
     totalleveltimes = 0;
@@ -3174,6 +3176,9 @@ void G_DoSaveGame(void)
     CT_SetMessage(&players[consoleplayer], DEH_String(TXT_GAMESAVED), true, NULL);
 
     free(filename);
+
+    // draw the pattern into the back screen
+    R_FillBackScreen();
 }
 
 //

--- a/src/heretic/in_lude.c
+++ b/src/heretic/in_lude.c
@@ -223,7 +223,6 @@ void IN_Stop(void)
     intermission = false;
     IN_UnloadPics();
     SB_state = -1;
-    BorderNeedRefresh = true;
 }
 
 //========================================================================

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -1091,6 +1091,7 @@ static void M_ID_TrueColorHook (void)
 {
     I_SetPalette (sb_palette);
     R_InitColormaps();
+    R_FillBackScreen();
 }
 #endif
 
@@ -1111,10 +1112,10 @@ static void M_ID_RenderingResHook (void)
     I_ReInitGraphics(REINIT_FRAMEBUFFERS | REINIT_TEXTURES | REINIT_ASPECTRATIO);
     // [crispy] re-calculate framebuffer coordinates
     R_ExecuteSetViewSize();
+    // [crispy] re-draw bezel
+    R_FillBackScreen();
     // [JN] re-calculate sky texture scaling
     R_InitSkyMap();
-    // [crispy] re-draw bezel
-    BorderNeedRefresh = true;
     // [crispy] re-calculate automap coordinates
     AM_LevelInit(true);
     if (automapactive)
@@ -1136,10 +1137,10 @@ static void M_ID_WidescreenHook (void)
     I_ReInitGraphics(REINIT_FRAMEBUFFERS | REINIT_TEXTURES | REINIT_ASPECTRATIO);
     // [crispy] re-calculate framebuffer coordinates
     R_ExecuteSetViewSize();
+    // [crispy] re-draw bezel
+    R_FillBackScreen();
     // [JN] re-calculate sky texture scaling
     R_InitSkyMap();
-    // [crispy] re-draw bezel
-    BorderNeedRefresh = true;
     // [crispy] re-calculate automap coordinates
     AM_LevelInit(true);
     if (automapactive)
@@ -1335,6 +1336,7 @@ static boolean M_ID_Gamma (int choice)
 #else
     I_SetPalette(sb_palette);
     R_InitColormaps();
+    R_FillBackScreen();
     SB_ForceRedraw();
 #endif
     return true;
@@ -1371,6 +1373,7 @@ static boolean M_ID_Saturation (int choice)
     I_SetPalette ((byte *)W_CacheLumpName(DEH_String("PLAYPAL"), PU_CACHE) + sb_palette * 768);
 #else
     R_InitColormaps();
+    R_FillBackScreen();
     SB_ForceRedraw();
     AM_Init();
 #endif
@@ -1385,6 +1388,7 @@ static boolean M_ID_R_Intensity (int choice)
     I_SetPalette ((byte *)W_CacheLumpName(DEH_String("PLAYPAL"), PU_CACHE) + sb_palette * 768);
 #else
     R_InitColormaps();
+    R_FillBackScreen();
     SB_ForceRedraw();
     AM_Init();
 #endif
@@ -1399,6 +1403,7 @@ static boolean M_ID_G_Intensity (int choice)
     I_SetPalette ((byte *)W_CacheLumpName(DEH_String("PLAYPAL"), PU_CACHE) + sb_palette * 768);
 #else
     R_InitColormaps();
+    R_FillBackScreen();
     SB_ForceRedraw();
     AM_Init();
 #endif
@@ -1413,6 +1418,7 @@ static boolean M_ID_B_Intensity (int choice)
     I_SetPalette ((byte *)W_CacheLumpName(DEH_String("PLAYPAL"), PU_CACHE) + sb_palette * 768);
 #else
     R_InitColormaps();
+    R_FillBackScreen();
     SB_ForceRedraw();
     AM_Init();
 #endif
@@ -4113,6 +4119,7 @@ static void M_ID_ApplyResetHook (void)
     I_SetPalette(sb_palette);
 #endif
     R_InitColormaps();
+    R_FillBackScreen();
     AM_LevelInit(true);
     if (automapactive)
     {
@@ -4544,10 +4551,6 @@ void MN_Drawer(void)
             MN_DrawInfo();
             return;
         }
-        if (dp_screen_size < 10)
-        {
-            BorderNeedRefresh = true;
-        }
         if (CurrentMenu->drawFunc != NULL)
         {
             CurrentMenu->drawFunc();
@@ -4911,7 +4914,6 @@ static boolean SCLoadGame(int option)
     free(filename);
 
     MN_DeactivateMenu();
-    BorderNeedRefresh = true;
     if (quickload == -1)
     {
         quickload = option + 1;
@@ -4935,7 +4937,6 @@ static boolean SCDeleteGame(int option)
     free(filename);
 
     MN_LoadSlotText();
-    BorderNeedRefresh = true;
 
     return true;
 }
@@ -4997,7 +4998,6 @@ static boolean SCSaveGame(int option)
         I_StopTextInput();
         MN_DeactivateMenu();
     }
-    BorderNeedRefresh = true;
     if (quicksave == -1)
     {
         quicksave = option + 1;
@@ -5366,7 +5366,6 @@ boolean MN_Responder(event_t * event)
             paused = false;
             MN_DeactivateMenu();
             SB_state = -1;      //refresh the statbar
-            BorderNeedRefresh = true;
         }
         S_StartSound(NULL, sfx_dorcls);
         return (true);          //make the info screen eat the keypress
@@ -5448,19 +5447,16 @@ boolean MN_Responder(event_t * event)
                                  "QUICKSAVING....", false, NULL);
                     FileMenuKeySteal = true;
                     SCSaveGame(quicksave - 1);
-                    BorderNeedRefresh = true;
                     break;
 
                 case 4:
                     CT_SetMessage(&players[consoleplayer],
                                  "QUICKLOADING....", false, NULL);
                     SCLoadGame(quickload - 1);
-                    BorderNeedRefresh = true;
                     break;
 
                 case 5:
                     SCDeleteGame(CurrentItPos);
-                    BorderNeedRefresh = true;
                     MN_ReturnToMenu();
                     break;
 
@@ -5518,7 +5514,6 @@ boolean MN_Responder(event_t * event)
                 typeofask = 0;
                 paused = false;
                 UpdateState |= I_FULLSCRN;
-                BorderNeedRefresh = true;
                 return true;
             }
         }
@@ -5536,7 +5531,6 @@ boolean MN_Responder(event_t * event)
             }
             SCScreenSize(LEFT_DIR);
             S_StartSound(NULL, sfx_keyup);
-            BorderNeedRefresh = true;
             UpdateState |= I_FULLSCRN;
             return (true);
         }
@@ -5548,7 +5542,6 @@ boolean MN_Responder(event_t * event)
             }
             SCScreenSize(RIGHT_DIR);
             S_StartSound(NULL, sfx_keyup);
-            BorderNeedRefresh = true;
             UpdateState |= I_FULLSCRN;
             return (true);
         }
@@ -5776,7 +5769,7 @@ boolean MN_Responder(event_t * event)
 #else
         I_SetPalette(0);
         R_InitColormaps();
-        BorderNeedRefresh = true;
+        R_FillBackScreen();
         SB_state = -1;
 #endif
         return true;

--- a/src/heretic/p_user.c
+++ b/src/heretic/p_user.c
@@ -749,7 +749,6 @@ void P_PlayerThink(player_t * player)
 
             player->mo->flags2 &= ~MF2_FLY;
             player->mo->flags &= ~MF_NOGRAVITY;
-            BorderTopRefresh = true;    //make sure the sprite's cleared out
         }
     }
     if (player->powers[pw_weaponlevel2])
@@ -771,7 +770,6 @@ void P_PlayerThink(player_t * player)
             {
                 player->pendingweapon = player->readyweapon;
             }
-            BorderTopRefresh = true;
         }
     }
     if (player->damagecount)

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -546,6 +546,12 @@ void R_InitBuffer(int width, int height)
         ylookup[i] = I_VideoBuffer + (i + viewwindowy) * SCREENWIDTH;
 }
 
+// -----------------------------------------------------------------------------
+// [JN] Replaced Heretic's original R_DrawViewBorder and R_DrawTopBorder
+// functions with Doom's implementation to improve performance and avoid
+// precision problems when drawing beveled edges on smaller screen sizes.
+// -----------------------------------------------------------------------------
+
 void R_FillBackScreen (void) 
 { 
 	byte    *src;

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -612,7 +612,6 @@ void R_FillBackScreen (void)
 				W_CacheLumpName(DEH_String("bordbl"), PU_CACHE));
                 
 	V_RestoreBuffer();
-	printf ("☻");
 } 
 
 
@@ -626,10 +625,13 @@ static void R_VideoErase (unsigned ofs, int count)
 
 void R_DrawViewBorder (void) 
 { 
-	int top;
+	int top, top2;
 	int side;
 	int ofs;
 	int i; 
+    
+	// [JN] Attempt to round up precision problem on lower screen sizes.
+	const int yy = dp_screen_size < 6 ? 1 : 0;
 	
 	if (scaledviewwidth == SCREENWIDTH)
 	{
@@ -637,6 +639,7 @@ void R_DrawViewBorder (void)
 	}
 
 	top = ((SCREENHEIGHT - SBARHEIGHT) - viewheight) / 2;
+	top2 = ((SCREENHEIGHT - SBARHEIGHT) - viewheight + yy) / 2;
 	side = (SCREENWIDTH - scaledviewwidth) / 2;
 
 	// copy top and one line of left side
@@ -644,7 +647,7 @@ void R_DrawViewBorder (void)
  
 	// copy one line of right side and bottom 
 	ofs = (viewheight + top) * SCREENWIDTH - side;
-	R_VideoErase(ofs, top * SCREENWIDTH + side);
+	R_VideoErase(ofs, top2 * SCREENWIDTH + side);
 
 	// copy sides using wraparound
 	ofs = top * SCREENWIDTH + SCREENWIDTH - side;

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -40,6 +40,10 @@ pixel_t *ylookup[MAXHEIGHT];
 int columnofs[MAXWIDTH];
 byte translations[3][256];      // color tables for different players
 
+// Backing buffer containing the bezel drawn around the screen and 
+// surrounding background.
+static pixel_t *background_buffer = NULL;
+
 /*
 ==================
 =
@@ -542,127 +546,116 @@ void R_InitBuffer(int width, int height)
         ylookup[i] = I_VideoBuffer + (i + viewwindowy) * SCREENWIDTH;
 }
 
+void R_FillBackScreen (void) 
+{ 
+	byte    *src;
+	pixel_t *dest;
+	int x;
+	int y;
+	
+	// If we are running full screen, there is no need to do any of this,
+	// and the background buffer can be freed if it was previously in use.
+	
+	if (scaledviewwidth == SCREENWIDTH)
+	{
+		if (background_buffer != NULL)
+		{
+			Z_Free(background_buffer);
+			background_buffer = NULL;
+		}
+		return;
+	}
+	
+	// Allocate the background buffer if necessary
+	
+	if (background_buffer == NULL)
+	{
+		background_buffer = Z_Malloc(MAXWIDTH * (MAXHEIGHT - SBARHEIGHT)
+						* sizeof(*background_buffer), PU_STATIC, NULL);
+	}
+	
+	src = W_CacheLumpName(DEH_String(gamemode == shareware ? "FLOOR04" : "FLAT513"), PU_CACHE); 
+	dest = background_buffer;
+	
+	// [crispy] use unified flat filling function
+	V_FillFlat(0, SCREENHEIGHT-SBARHEIGHT, 0, SCREENWIDTH, src, dest);
+	
+	// Draw screen and bezel; this is done to a separate screen buffer.
+	
+	V_UseBuffer(background_buffer);
 
-/*
-==================
-=
-= R_DrawViewBorder
-=
-= Draws the border around the view for different size windows
-==================
-*/
+	for (x = (viewwindowx / vid_resolution); x < (viewwindowx + viewwidth) / vid_resolution; x += 16)
+	{
+		V_DrawPatch(x - WIDESCREENDELTA, (viewwindowy / vid_resolution) - 4,
+					W_CacheLumpName(DEH_String("bordt"), PU_CACHE));
+		V_DrawPatch(x - WIDESCREENDELTA, (viewwindowy + viewheight) / vid_resolution,
+					W_CacheLumpName(DEH_String("bordb"), PU_CACHE));
+	}
+	for (y = (viewwindowy / vid_resolution); y < (viewwindowy + viewheight) / vid_resolution; y += 16)
+	{
+		V_DrawPatch((viewwindowx / vid_resolution) - 4 - WIDESCREENDELTA, y,
+					W_CacheLumpName(DEH_String("bordl"), PU_CACHE));
+		V_DrawPatch(((viewwindowx + viewwidth) / vid_resolution) - WIDESCREENDELTA, y,
+					W_CacheLumpName(DEH_String("bordr"), PU_CACHE));
+	}
+	V_DrawPatch((viewwindowx / vid_resolution) - 4 - WIDESCREENDELTA,
+				(viewwindowy / vid_resolution) - 4,
+				W_CacheLumpName(DEH_String("bordtl"), PU_CACHE));
+	V_DrawPatch(((viewwindowx + viewwidth) / vid_resolution) - WIDESCREENDELTA,
+				(viewwindowy / vid_resolution) - 4,
+				W_CacheLumpName(DEH_String("bordtr"), PU_CACHE));
+	V_DrawPatch(((viewwindowx + viewwidth) / vid_resolution) - WIDESCREENDELTA,
+				(viewwindowy + viewheight) / vid_resolution,
+				W_CacheLumpName(DEH_String("bordbr"), PU_CACHE));
+	V_DrawPatch((viewwindowx / vid_resolution) - 4 - WIDESCREENDELTA,
+				(viewwindowy + viewheight) / vid_resolution,
+				W_CacheLumpName(DEH_String("bordbl"), PU_CACHE));
+                
+	V_RestoreBuffer();
+	printf ("☻");
+} 
 
-boolean BorderNeedRefresh;
 
-void R_DrawViewBorder(void)
-{
-    byte *src;
-    pixel_t *dest;
-    int x, y;
+static void R_VideoErase (unsigned ofs, int count)
+{ 
+	if (background_buffer != NULL)
+	{
+		memcpy(I_VideoBuffer + ofs, background_buffer + ofs, count * sizeof(*I_VideoBuffer));
+	}
+} 
 
-    if (scaledviewwidth == SCREENWIDTH)
-        return;
+void R_DrawViewBorder (void) 
+{ 
+	int top;
+	int side;
+	int ofs;
+	int i; 
+	
+	if (scaledviewwidth == SCREENWIDTH)
+	{
+		return;
+	}
 
-    if (gamemode == shareware)
-    {
-        src = W_CacheLumpName(DEH_String("FLOOR04"), PU_CACHE);
-    }
-    else
-    {
-        src = W_CacheLumpName(DEH_String("FLAT513"), PU_CACHE);
-    }
-    dest = I_VideoBuffer;
+	top = ((SCREENHEIGHT - SBARHEIGHT) - viewheight) / 2;
+	side = (SCREENWIDTH - scaledviewwidth) / 2;
 
-    // [crispy] use unified flat filling function
-    V_FillFlat(0, SCREENHEIGHT - SBARHEIGHT, 0, SCREENWIDTH, src, dest);
+	// copy top and one line of left side
+	R_VideoErase(0, top * SCREENWIDTH + side);
+ 
+	// copy one line of right side and bottom 
+	ofs = (viewheight + top) * SCREENWIDTH - side;
+	R_VideoErase(ofs, top * SCREENWIDTH + side);
 
-    for (x = (viewwindowx / vid_resolution); x < (viewwindowx + viewwidth) / vid_resolution; x += 16)
-    {
-        V_DrawPatch(x - WIDESCREENDELTA, (viewwindowy / vid_resolution) - 4,
-                    W_CacheLumpName(DEH_String("bordt"), PU_CACHE));
-        V_DrawPatch(x - WIDESCREENDELTA, (viewwindowy + viewheight) / vid_resolution,
-                    W_CacheLumpName(DEH_String("bordb"), PU_CACHE));
-    }
-    for (y = (viewwindowy / vid_resolution); y < (viewwindowy + viewheight) / vid_resolution; y += 16)
-    {
-        V_DrawPatch((viewwindowx / vid_resolution) - 4 - WIDESCREENDELTA, y,
-                    W_CacheLumpName(DEH_String("bordl"), PU_CACHE));
-        V_DrawPatch(((viewwindowx + viewwidth) / vid_resolution) - WIDESCREENDELTA, y,
-                    W_CacheLumpName(DEH_String("bordr"), PU_CACHE));
-    }
-    V_DrawPatch((viewwindowx / vid_resolution) - 4 - WIDESCREENDELTA,
-                (viewwindowy / vid_resolution) - 4,
-                W_CacheLumpName(DEH_String("bordtl"), PU_CACHE));
-    V_DrawPatch(((viewwindowx + viewwidth) / vid_resolution) - WIDESCREENDELTA,
-                (viewwindowy / vid_resolution) - 4,
-                W_CacheLumpName(DEH_String("bordtr"), PU_CACHE));
-    V_DrawPatch(((viewwindowx + viewwidth) / vid_resolution) - WIDESCREENDELTA,
-                (viewwindowy + viewheight) / vid_resolution,
-                W_CacheLumpName(DEH_String("bordbr"), PU_CACHE));
-    V_DrawPatch((viewwindowx / vid_resolution) - 4 - WIDESCREENDELTA,
-                (viewwindowy + viewheight) / vid_resolution,
-                W_CacheLumpName(DEH_String("bordbl"), PU_CACHE));
-}
+	// copy sides using wraparound
+	ofs = top * SCREENWIDTH + SCREENWIDTH - side;
+	side <<= 1;
 
-/*
-==================
-=
-= R_DrawTopBorder
-=
-= Draws the top border around the view for different size windows
-==================
-*/
+	for (i = 1 ; i < viewheight ; i++)
+	{
+		R_VideoErase (ofs, side);
+		ofs += SCREENWIDTH;
+	} 
 
-boolean BorderTopRefresh;
-
-void R_DrawTopBorder(void)
-{
-    byte *src;
-    pixel_t *dest;
-
-    if (scaledviewwidth == SCREENWIDTH)
-        return;
-
-    if (gamemode == shareware)
-    {
-        src = W_CacheLumpName(DEH_String("FLOOR04"), PU_CACHE);
-    }
-    else
-    {
-        src = W_CacheLumpName(DEH_String("FLAT513"), PU_CACHE);
-    }
-    dest = I_VideoBuffer;
-
-    // [crispy] use unified flat filling function
-    V_FillFlat(0, 30 * vid_resolution, 0, SCREENWIDTH, src, dest);
-
-    if ((viewwindowy / vid_resolution) < 25)
-    {
-        int x;
-
-        for (x = (viewwindowx / vid_resolution); x < (viewwindowx + viewwidth) / vid_resolution; x += 16)
-        {
-            V_DrawPatch(x - WIDESCREENDELTA, (viewwindowy / vid_resolution) - 4,
-                        W_CacheLumpName(DEH_String("bordt"), PU_CACHE));
-        }
-        V_DrawPatch((viewwindowx / vid_resolution) - 4 - WIDESCREENDELTA,
-                    viewwindowy / vid_resolution,
-                    W_CacheLumpName(DEH_String("bordl"), PU_CACHE));
-        V_DrawPatch(((viewwindowx + viewwidth) / vid_resolution) - WIDESCREENDELTA,
-                    viewwindowy / vid_resolution,
-                    W_CacheLumpName(DEH_String("bordr"), PU_CACHE));
-        V_DrawPatch((viewwindowx / vid_resolution) - 4 - WIDESCREENDELTA,
-                    (viewwindowy / vid_resolution) + 16,
-                    W_CacheLumpName(DEH_String("bordl"), PU_CACHE));
-        V_DrawPatch(((viewwindowx + viewwidth) / vid_resolution) - WIDESCREENDELTA,
-                    (viewwindowy / vid_resolution) + 16,
-                    W_CacheLumpName(DEH_String("bordr"), PU_CACHE));
-
-        V_DrawPatch((viewwindowx / vid_resolution) - 4 - WIDESCREENDELTA,
-                    (viewwindowy / vid_resolution) - 4,
-                    W_CacheLumpName(DEH_String("bordtl"), PU_CACHE));
-        V_DrawPatch(((viewwindowx + viewwidth) / vid_resolution) - WIDESCREENDELTA,
-                    (viewwindowy / vid_resolution) - 4,
-                    W_CacheLumpName(DEH_String("bordtr"), PU_CACHE));
-    }
+	// ?
+	V_MarkRect(0, 0, SCREENWIDTH, SCREENHEIGHT - SBARHEIGHT);
 }

--- a/src/heretic/r_main.c
+++ b/src/heretic/r_main.c
@@ -1123,25 +1123,6 @@ void R_SetupFrame (player_t* player)
         fixedcolormap = 0;
     }
     validcount++;
-    if (BorderNeedRefresh)
-    {
-        if (setblocks < 10)
-        {
-            R_DrawViewBorder();
-        }
-        BorderNeedRefresh = false;
-        BorderTopRefresh = false;
-        UpdateState |= I_FULLSCRN;
-    }
-    if (BorderTopRefresh)
-    {
-        if (setblocks < 10)
-        {
-            R_DrawTopBorder();
-        }
-        BorderTopRefresh = false;
-        UpdateState |= I_MESSAGES;
-    }
 }
 
 //

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -609,7 +609,6 @@ static void DrawSoundInfo(void)
         MN_DrTextA(text, xPos[x++], y, NULL);
     }
     UpdateState |= I_FULLSCRN;
-    BorderNeedRefresh = true;
 }
 
 //---------------------------------------------------------------------------
@@ -820,12 +819,10 @@ void SB_Drawer(void)
                     hitCenterFrame = true;
                 }
             }
-            BorderTopRefresh = true;
             UpdateState |= I_MESSAGES;
         }
         else
         {
-            BorderTopRefresh = true;
             UpdateState |= I_MESSAGES;
         }
     }
@@ -849,12 +846,10 @@ void SB_Drawer(void)
             frame = (leveltime / 3) & 15;
             V_DrawPatch(spinbook_x, 17,
                         W_CacheLumpNum(spinbooklump + frame, PU_CACHE));
-            BorderTopRefresh = true;
             UpdateState |= I_MESSAGES;
         }
         else
         {
-            BorderTopRefresh = true;
             UpdateState |= I_MESSAGES;
         }
     }

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -819,11 +819,6 @@ void SB_Drawer(void)
                     hitCenterFrame = true;
                 }
             }
-            UpdateState |= I_MESSAGES;
-        }
-        else
-        {
-            UpdateState |= I_MESSAGES;
         }
     }
 
@@ -846,11 +841,6 @@ void SB_Drawer(void)
             frame = (leveltime / 3) & 15;
             V_DrawPatch(spinbook_x, 17,
                         W_CacheLumpNum(spinbooklump + frame, PU_CACHE));
-            UpdateState |= I_MESSAGES;
-        }
-        else
-        {
-            UpdateState |= I_MESSAGES;
         }
     }
 


### PR DESCRIPTION
This should fix background of some widgets not being properly updated as well as font's shadows goes to maximum black:

![image](https://github.com/JNechaevsky/international-doom/assets/21193394/fd9f00f8-e6a6-41bc-a65a-3bdd334fb128)

The trick here is not to re-draw whole bezel every game tic or every frame, but instead, operate with buffered copy of bezel which is safe for performance and FPS. Just like it is done in Doom.