### PR TITLE
Heretic: colored ammo widget

### DIFF
--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -551,6 +551,8 @@ static boolean M_ID_CrosshairColor (int choice);
 static void M_Draw_ID_Gameplay_2 (void);
 static boolean M_ID_ColoredSBar (int choice);
 static boolean M_ID_AmmoWidget (int choice);
+static boolean M_ID_AmmoWidgetTranslucent (int choice);
+static boolean M_ID_AmmoWidgetColors (int choice);
 static boolean M_ID_ZAxisSfx (int choice);
 static boolean M_ID_Torque (int choice);
 static boolean M_ID_WeaponAlignment (int choice);
@@ -3132,14 +3134,14 @@ static boolean M_ID_CrosshairColor (int choice)
 static MenuItem_t ID_Menu_Gameplay_2[] = {
     { ITT_LRFUNC,  "COLORED ELEMENTS",            M_ID_ColoredSBar,     0, MENU_NONE         },
     { ITT_LRFUNC,  "SHOW AMMO WIDGET",            M_ID_AmmoWidget,      0, MENU_NONE         },
+    { ITT_LRFUNC,  "AMMO WIDGET TRANSLUCENCY",    M_ID_AmmoWidgetTranslucent, 0, MENU_NONE   },
+    { ITT_LRFUNC,  "AMMO WIDGET COLORING",        M_ID_AmmoWidgetColors,0, MENU_NONE         },
     { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
     { ITT_LRFUNC,  "SFX ATTENUATION AXISES",      M_ID_ZAxisSfx,        0, MENU_NONE         },
     { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
     { ITT_LRFUNC,  "CORPSES SLIDING FROM LEDGES", M_ID_Torque,          0, MENU_NONE         },
     { ITT_LRFUNC,  "WEAPON ATTACK ALIGNMENT",     M_ID_WeaponAlignment, 0, MENU_NONE         },
     { ITT_LRFUNC,  "IMITATE PLAYER'S BREATHING",  M_ID_Breathing,       0, MENU_NONE         },
-    { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
-    { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
     { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
     { ITT_SETMENU, "", /*LAST PAGE >*/            NULL,                 0, MENU_ID_GAMEPLAY3 },
     { ITT_SETMENU, "", /*< FIRST PAGE*/           NULL,                 0, MENU_ID_GAMEPLAY1 },
@@ -3169,36 +3171,46 @@ static void M_Draw_ID_Gameplay_2 (void)
 
     // Ammo widget
     sprintf(str, st_ammo_widget == 1 ? "BRIEF" :
-                 st_ammo_widget == 2 ? "BRIEF+TRANSLUCENT" :
-                 st_ammo_widget == 3 ? "FULL" :
-                 st_ammo_widget == 4 ? "FULL+TRANSLUCENT" : "OFF");
+                 st_ammo_widget == 2 ? "FULL" : "OFF");
     MN_DrTextA(str, M_ItemRightAlign(str), 30,
                M_Item_Glow(1, st_ammo_widget ? GLOW_GREEN : GLOW_DARKRED));
 
-    MN_DrTextACentered("AUDIBLE", 40, cr[CR_YELLOW]);
+    // Ammo widget translucency
+    sprintf(str, st_ammo_widget_translucent ? "ON" : "OFF");
+    MN_DrTextA(str, M_ItemRightAlign(str), 40,
+               M_Item_Glow(2, st_ammo_widget_translucent ? GLOW_GREEN : GLOW_DARKRED));
+
+    // Ammo widget colors
+    sprintf(str, st_ammo_widget_colors == 1 ? "AMMO+WEAPONS" :
+                 st_ammo_widget_colors == 2 ? "AMMO ONLY" :
+                 st_ammo_widget_colors == 3 ? "WEAPONS ONLY" : "OFF");
+    MN_DrTextA(str, M_ItemRightAlign(str), 50,
+               M_Item_Glow(3, st_ammo_widget_colors ? GLOW_GREEN : GLOW_DARKRED));
+
+    MN_DrTextACentered("AUDIBLE", 60, cr[CR_YELLOW]);
 
     // Sfx attenuation axises
     sprintf(str, aud_z_axis_sfx ? "X/Y/Z" : "X/Y");
-    MN_DrTextA(str, M_ItemRightAlign(str), 50,
-               M_Item_Glow(3, aud_z_axis_sfx ? GLOW_GREEN : GLOW_DARKRED));
+    MN_DrTextA(str, M_ItemRightAlign(str), 70,
+               M_Item_Glow(5, aud_z_axis_sfx ? GLOW_GREEN : GLOW_DARKRED));
 
-    MN_DrTextACentered("PHYSICAL", 60, cr[CR_YELLOW]);
+    MN_DrTextACentered("PHYSICAL", 80, cr[CR_YELLOW]);
 
     // Corpses sliding from ledges
     sprintf(str, phys_torque ? "ON" : "OFF");
-    MN_DrTextA(str, M_ItemRightAlign(str), 70,
-               M_Item_Glow(5, phys_torque ? GLOW_GREEN : GLOW_DARKRED));
+    MN_DrTextA(str, M_ItemRightAlign(str), 90,
+               M_Item_Glow(7, phys_torque ? GLOW_GREEN : GLOW_DARKRED));
 
     // Weapon attack alignment
     sprintf(str, phys_weapon_alignment == 1 ? "BOBBING" :
                  phys_weapon_alignment == 2 ? "CENTERED" : "ORIGINAL");
-    MN_DrTextA(str, M_ItemRightAlign(str), 80,
-               M_Item_Glow(6, phys_weapon_alignment ? GLOW_GREEN : GLOW_DARKRED));
+    MN_DrTextA(str, M_ItemRightAlign(str), 100,
+               M_Item_Glow(8, phys_weapon_alignment ? GLOW_GREEN : GLOW_DARKRED));
 
     // Imitate player's breathing
     sprintf(str, phys_breathing ? "ON" : "OFF");
-    MN_DrTextA(str, M_ItemRightAlign(str), 90,
-               M_Item_Glow(7, phys_breathing ? GLOW_GREEN : GLOW_DARKRED));
+    MN_DrTextA(str, M_ItemRightAlign(str), 110,
+               M_Item_Glow(9, phys_breathing ? GLOW_GREEN : GLOW_DARKRED));
 
     MN_DrTextA("LAST PAGE", ID_MENU_LEFTOFFSET_BIG, 130,
                M_Item_Glow(11, GLOW_DARKGRAY));
@@ -3218,10 +3230,21 @@ static boolean M_ID_ColoredSBar (int choice)
 
 static boolean M_ID_AmmoWidget (int choice)
 {
-    st_ammo_widget = M_INT_Slider(st_ammo_widget, 0, 4, choice, false);
+    st_ammo_widget = M_INT_Slider(st_ammo_widget, 0, 2, choice, false);
     return true;
 }
 
+static boolean M_ID_AmmoWidgetTranslucent (int choice)
+{
+    st_ammo_widget_translucent = M_INT_Slider(st_ammo_widget_translucent, 0, 1, choice, false);
+    return true;
+}
+
+static boolean M_ID_AmmoWidgetColors (int choice)
+{
+    st_ammo_widget_colors = M_INT_Slider(st_ammo_widget_colors, 0, 3, choice, false);
+    return true;
+}
 static boolean M_ID_ZAxisSfx (int choice)
 {
     aud_z_axis_sfx ^= 1;
@@ -4077,6 +4100,8 @@ static void M_ID_ApplyResetHook (void)
     // Status bar
     st_colored_stbar = 0;
     st_ammo_widget = 0;
+    st_ammo_widget_translucent = 0;
+    st_ammo_widget_colors = 0;
 
     // Audible
     aud_z_axis_sfx = 0;

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -699,6 +699,67 @@ static void RefreshBackground(void)
     V_CopyRect(0, 0, st_backing_screen, SCREENWIDTH, SBARHEIGHT, 0, 158 * vid_resolution);
 }
 
+enum
+{
+    ammowidgetcolor_ammo,
+    ammowidgetcolor_weapon
+} ammowidgetcolor_t;
+
+
+// -----------------------------------------------------------------------------
+// SB_AmmoWidgetColor
+// [international-doom] return ammo/health/armor widget color
+// -----------------------------------------------------------------------------
+
+static byte *SB_AmmoWidgetColor (int i, weapontype_t weapon)
+{
+    switch (i)
+    {
+        case ammowidgetcolor_ammo:
+        {
+
+            const int ammo = CPlayer->ammo[wpnlev1info[weapon].ammo];
+            const int fullammo = CPlayer->maxammo[wpnlev1info[weapon].ammo];
+
+            if (st_ammo_widget_colors != 1 && st_ammo_widget_colors != 2)
+            {
+                return cr[CR_GRAY];
+            }
+
+            if (ammo < fullammo/4)
+                return cr[CR_RED];
+            else if (ammo < fullammo/2)
+                return cr[CR_YELLOW];
+            else
+                return cr[CR_GREEN];
+        }
+        case ammowidgetcolor_weapon:
+        {
+            // always color the weapon letter if ammo widget coloring is OFF
+            if ((st_ammo_widget_colors != 1 && st_ammo_widget_colors != 3) ||
+                CPlayer->weaponowned[weapon] == true)
+            {
+                switch (weapon)
+                {
+                    case wp_goldwand:   return cr[CR_YELLOW];
+                    case wp_crossbow:   return cr[CR_GREEN];
+                    case wp_blaster:    return cr[CR_BLUE2];
+                    case wp_skullrod:   return cr[CR_RED];
+                    case wp_phoenixrod: return cr[CR_ORANGE];
+                    case wp_mace:       return cr[CR_LIGHTGRAY];
+                    default:            return cr[CR_GRAY];
+                }
+            }
+            else
+            {
+                return cr[CR_GRAY];
+            }
+        }
+    }
+
+    return NULL;
+}
+
 void SB_Drawer(void)
 {
     int frame;
@@ -872,36 +933,36 @@ void SB_Drawer(void)
         {
             dp_translucent = (st_ammo_widget_translucent);
 
-            MN_DrTextA("W", 282 + WIDESCREENDELTA,  96 + yy, cr[CR_YELLOW]);
-            MN_DrTextA("E", 282 + WIDESCREENDELTA, 106 + yy, cr[CR_GREEN]);
-            MN_DrTextA("D", 282 + WIDESCREENDELTA, 116 + yy, cr[CR_BLUE2]);
-            MN_DrTextA("H", 282 + WIDESCREENDELTA, 126 + yy, cr[CR_RED]);
-            MN_DrTextA("P", 282 + WIDESCREENDELTA, 136 + yy, cr[CR_ORANGE]);
-            MN_DrTextA("M", 282 + WIDESCREENDELTA, 146 + yy, cr[CR_LIGHTGRAY]);
+            MN_DrTextA("W", 282 + WIDESCREENDELTA,  96 + yy, SB_AmmoWidgetColor(ammowidgetcolor_weapon, wp_goldwand));
+            MN_DrTextA("E", 282 + WIDESCREENDELTA, 106 + yy, SB_AmmoWidgetColor(ammowidgetcolor_weapon, wp_crossbow));
+            MN_DrTextA("D", 282 + WIDESCREENDELTA, 116 + yy, SB_AmmoWidgetColor(ammowidgetcolor_weapon, wp_blaster));
+            MN_DrTextA("H", 282 + WIDESCREENDELTA, 126 + yy, SB_AmmoWidgetColor(ammowidgetcolor_weapon, wp_skullrod));
+            MN_DrTextA("P", 282 + WIDESCREENDELTA, 136 + yy, SB_AmmoWidgetColor(ammowidgetcolor_weapon, wp_phoenixrod));
+            MN_DrTextA("M", 282 + WIDESCREENDELTA, 146 + yy, SB_AmmoWidgetColor(ammowidgetcolor_weapon, wp_mace));
 
             // Elven Wand
             sprintf(str, "%d",  CPlayer->ammo[am_goldwand]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA, 96 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA, 96 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_goldwand));
 
             // Ethereal Crossbow
             sprintf(str, "%d",  CPlayer->ammo[am_crossbow]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA, 106 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA, 106 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_crossbow));
 
             // Dragon Claw
             sprintf(str, "%d",  CPlayer->ammo[am_blaster]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA, 116 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA, 116 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_blaster));
 
             // Hellstaff
             sprintf(str, "%d",  CPlayer->ammo[am_skullrod]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA, 126 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA, 126 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_skullrod));
 
             // Phoenix Rod
             sprintf(str, "%d",  CPlayer->ammo[am_phoenixrod]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA, 136 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA, 136 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_phoenixrod));
 
             // Firemace
             sprintf(str, "%d",  CPlayer->ammo[am_mace]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA, 146 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA, 146 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_mace));
 
             dp_translucent = false;
         }
@@ -910,48 +971,48 @@ void SB_Drawer(void)
         {
             dp_translucent = (st_ammo_widget_translucent);
 
-            MN_DrTextA("W", 251 + WIDESCREENDELTA,  96 + yy, cr[CR_YELLOW]);
-            MN_DrTextA("E", 251 + WIDESCREENDELTA, 106 + yy, cr[CR_GREEN]);
-            MN_DrTextA("D", 251 + WIDESCREENDELTA, 116 + yy, cr[CR_BLUE2]);
-            MN_DrTextA("H", 251 + WIDESCREENDELTA, 126 + yy, cr[CR_RED]);
-            MN_DrTextA("P", 251 + WIDESCREENDELTA, 136 + yy, cr[CR_ORANGE]);
-            MN_DrTextA("M", 251 + WIDESCREENDELTA, 146 + yy, cr[CR_LIGHTGRAY]);
+            MN_DrTextA("W", 251 + WIDESCREENDELTA,  96 + yy, SB_AmmoWidgetColor(ammowidgetcolor_weapon, wp_goldwand));
+            MN_DrTextA("E", 251 + WIDESCREENDELTA, 106 + yy, SB_AmmoWidgetColor(ammowidgetcolor_weapon, wp_crossbow));
+            MN_DrTextA("D", 251 + WIDESCREENDELTA, 116 + yy, SB_AmmoWidgetColor(ammowidgetcolor_weapon, wp_blaster));
+            MN_DrTextA("H", 251 + WIDESCREENDELTA, 126 + yy, SB_AmmoWidgetColor(ammowidgetcolor_weapon, wp_skullrod));
+            MN_DrTextA("P", 251 + WIDESCREENDELTA, 136 + yy, SB_AmmoWidgetColor(ammowidgetcolor_weapon, wp_phoenixrod));
+            MN_DrTextA("M", 251 + WIDESCREENDELTA, 146 + yy, SB_AmmoWidgetColor(ammowidgetcolor_weapon, wp_mace));
 
             // Elven Wand
             sprintf(str, "%d/",  CPlayer->ammo[am_goldwand]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA - MN_TextAWidth(str), 96 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA - MN_TextAWidth(str), 96 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_goldwand));
             sprintf(str, "%d",  CPlayer->maxammo[am_goldwand]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA, 96 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA, 96 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_goldwand));
 
             // Ethereal Crossbow
             sprintf(str, "%d/",  CPlayer->ammo[am_crossbow]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA - MN_TextAWidth(str), 106 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA - MN_TextAWidth(str), 106 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_crossbow));
             sprintf(str, "%d",  CPlayer->maxammo[am_crossbow]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA, 106 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA, 106 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_crossbow));
 
             // Dragon Claw
             sprintf(str, "%d/",  CPlayer->ammo[am_blaster]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA - MN_TextAWidth(str), 116 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA - MN_TextAWidth(str), 116 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_blaster));
             sprintf(str, "%d",  CPlayer->maxammo[am_blaster]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA, 116 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA, 116 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_blaster));
 
             // Hellstaff
             sprintf(str, "%d/",  CPlayer->ammo[am_skullrod]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA - MN_TextAWidth(str), 126 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA - MN_TextAWidth(str), 126 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_skullrod));
             sprintf(str, "%d",  CPlayer->maxammo[am_skullrod]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA, 126 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA, 126 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_skullrod));
 
             // Phoenix Rod
             sprintf(str, "%d/",  CPlayer->ammo[am_phoenixrod]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA - MN_TextAWidth(str), 136 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA - MN_TextAWidth(str), 136 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_phoenixrod));
             sprintf(str, "%d",  CPlayer->maxammo[am_phoenixrod]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA, 136 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA, 136 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_phoenixrod));
 
             // Firemace
             sprintf(str, "%d/",  CPlayer->ammo[am_mace]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA - MN_TextAWidth(str), 146 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA - MN_TextAWidth(str), 146 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_mace));
             sprintf(str, "%d",  CPlayer->maxammo[am_mace]);
-            MN_DrTextA(str, 293 + WIDESCREENDELTA, 146 + yy, cr[CR_GRAY]);
+            MN_DrTextA(str, 293 + WIDESCREENDELTA, 146 + yy, SB_AmmoWidgetColor(ammowidgetcolor_ammo, wp_mace));
 
             dp_translucent = false;
         }

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -868,9 +868,9 @@ void SB_Drawer(void)
                         && (!automapactive || automap_overlay) ? 13 : 0;
 
         // Brief
-        if (st_ammo_widget < 3)
+        if (st_ammo_widget == 1)
         {
-            dp_translucent = (st_ammo_widget == 2);
+            dp_translucent = (st_ammo_widget_translucent);
 
             MN_DrTextA("W", 282 + WIDESCREENDELTA,  96 + yy, cr[CR_YELLOW]);
             MN_DrTextA("E", 282 + WIDESCREENDELTA, 106 + yy, cr[CR_GREEN]);
@@ -908,7 +908,7 @@ void SB_Drawer(void)
         // Full
         else
         {
-            dp_translucent = (st_ammo_widget == 4);
+            dp_translucent = (st_ammo_widget_translucent);
 
             MN_DrTextA("W", 251 + WIDESCREENDELTA,  96 + yy, cr[CR_YELLOW]);
             MN_DrTextA("E", 251 + WIDESCREENDELTA, 106 + yy, cr[CR_GREEN]);

--- a/src/id_vars.c
+++ b/src/id_vars.c
@@ -126,6 +126,8 @@ int st_colored_stbar = 0;
 int st_negative_health = 0;
 int st_blinking_keys = 0;
 int st_ammo_widget = 0;
+int st_ammo_widget_translucent = 0;
+int st_ammo_widget_colors = 0;
 
 // Audible
 int aud_z_axis_sfx = 0;
@@ -277,6 +279,8 @@ void ID_BindVariables (GameMission_t mission)
     if (mission == heretic)
     {
         M_BindIntVariable("st_ammo_widget",             &st_ammo_widget);
+        M_BindIntVariable("st_ammo_widget_translucent", &st_ammo_widget_translucent);
+        M_BindIntVariable("st_ammo_widget_colors",      &st_ammo_widget_colors);
     }
     
     // Audible

--- a/src/id_vars.h
+++ b/src/id_vars.h
@@ -104,6 +104,8 @@ extern int st_colored_stbar;
 extern int st_negative_health;
 extern int st_blinking_keys;
 extern int st_ammo_widget;  // Heretic only
+extern int st_ammo_widget_translucent;  // Heretic only
+extern int st_ammo_widget_colors;  // Heretic only
 
 extern int aud_z_axis_sfx;
 extern int aud_full_sounds;

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -496,6 +496,8 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_INT(st_negative_health),
     CONFIG_VARIABLE_INT(st_blinking_keys),
     CONFIG_VARIABLE_INT(st_ammo_widget),
+    CONFIG_VARIABLE_INT(st_ammo_widget_translucent),
+    CONFIG_VARIABLE_INT(st_ammo_widget_colors),
 
     // Audible
     CONFIG_VARIABLE_INT(aud_z_axis_sfx),


### PR DESCRIPTION
Closes #45 

Things for you to check/decide on:

- Line lengths, variable lengths, general formatting. [This line](https://github.com/JNechaevsky/international-doom/commit/8332db94e6cc2b5037f393d1b8d1e3628cad30c8#diff-ebca5aac746b7e31419da0d1099371152b08942d1bb47b7a554cd4e716b7dfa0R3137) is ugly but I don't know your preference for extending the whole table.
- The name "ammo widget coloring" is kind of confusing since the weapon letters are colored even when it's off, but there's only so much room to type. "Extend widget colors" maybe?
- I put in multiple options for coloring the ammo/weapons but maybe you want it just on/off.
- SB_AmmoWidgetColor could be broken into two functions

Thanks!