### PR TITLE
Heretic: fix hitscan/missile puffs disappearing in certain areas

### DIFF
--- a/src/heretic/p_local.h
+++ b/src/heretic/p_local.h
@@ -137,6 +137,7 @@ extern mobjtype_t PuffType;
 extern mobj_t *MissileMobj;
 
 mobj_t *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type);
+mobj_t *P_SpawnMobjSafe(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type, boolean safe);
 void P_RemoveMobj(mobj_t * th);
 boolean P_SetMobjState(mobj_t * mobj, statenum_t state);
 boolean P_SetMobjStateNF(mobj_t * mobj, statenum_t state);
@@ -146,6 +147,7 @@ boolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax);
 void P_MobjThinker(thinker_t * thinker);
 void P_BlasterMobjThinker(thinker_t * thinker);
 void P_SpawnPuff(fixed_t x, fixed_t y, fixed_t z);
+void P_SpawnPuffSafe(fixed_t x, fixed_t y, fixed_t z, boolean safe);
 void P_SpawnBlood(fixed_t x, fixed_t y, fixed_t z, int damage);
 void P_SpawnPlayer(mapthing_t * mthing);
 void P_BloodSplatter(fixed_t x, fixed_t y, fixed_t z, mobj_t * originator);

--- a/src/heretic/p_map.c
+++ b/src/heretic/p_map.c
@@ -1493,6 +1493,7 @@ boolean PTR_ShootTraverse(intercept_t * in)
 
     if (in->isaline)
     {
+        boolean safe = false;
         li = in->d.line;
         if (li->special)
             P_ShootSpecialLine(shootthing, li);
@@ -1536,10 +1537,39 @@ boolean PTR_ShootTraverse(intercept_t * in)
             if (z > li->frontsector->ceilingheight)
                 return false;   // don't shoot the sky!
             if (li->backsector && li->backsector->ceilingpic == skyflatnum)
+            {
+                // [crispy] fix bullet puffs and laser spot not appearing in outdoor areas
+                if (li->backsector->ceilingheight < z)
                 return false;   // it's a sky hack wall
+                else
+                safe = true;
+            }
         }
 
-        P_SpawnPuff(x, y, z);
+        // [crispy] check if the pullet puff's z-coordinate is below of above
+        // its spawning sector's floor or ceiling, respectively, and move its
+        // coordinates to the point where the trajectory hits the plane
+        if (aimslope)
+        {
+            const int lineside = P_PointOnLineSide(x, y, li);
+            int side;
+
+            if ((side = li->sidenum[lineside]) != NO_INDEX)
+            {
+                const sector_t *const sector = sides[side].sector;
+
+                if (z < sector->floorheight ||
+                    (z > sector->ceilingheight && sector->ceilingpic != skyflatnum))
+                {
+                    z = BETWEEN(sector->floorheight, sector->ceilingheight, z);
+                    frac = FixedDiv(z - shootz, FixedMul(aimslope, attackrange));
+                    x = trace.x + FixedMul (trace.dx, frac);
+                    y = trace.y + FixedMul (trace.dy, frac);
+                }
+            }
+        }
+
+        P_SpawnPuffSafe(x, y, z, safe);
         return false;           // don't go any farther
     }
 


### PR DESCRIPTION
This is complex fix:
- Hitscan puffs now able to appear on floor/ceiling, even when bumped in front of back side 2-sided line (🤯...).
- Missile explosions no longer disappears on back sides to 2-sided lines, Phoenix Rod explosions are having just a visual effect in such cases.
- Safe for longest full 1-5 episode runs demos, but I still want to check it manually in the game.
- As small diff as possible.

 