### PR TITLE
Heretic: more automap improvements

### DIFF
--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -300,7 +300,7 @@ static byte antialias_normal[NUMALIAS][NUMLEVELS] = {
     {153, 153, 152, 152, 151, 151, 150, 150},
     {154, 154, 153, 153, 152, 152, 151, 151},
     {155, 155, 154, 154, 153, 153, 152, 152},
-    {156, 156, 155, 155, 154, 154, 153, 153},
+    {156, 156, 155, 155, 154, 154, 153, 153},   // Used for TELEPORTERS as well
     {157, 157, 156, 156, 155, 155, 154, 154},
     {158, 158, 157, 157, 156, 156, 155, 155},
     {159, 159, 158, 158, 157, 157, 156, 156},    
@@ -327,7 +327,7 @@ static byte antialias_overlay[NUMALIAS][NUMLEVELS] = {
     {153, 153, 152, 152, 151, 151, 150, 150},
     {154, 154, 153, 153, 152, 152, 151, 151},
     {155, 155, 154, 154, 153, 153, 152, 152},
-    {156, 156, 155, 155, 154, 154, 153, 153},
+    {156, 156, 155, 155, 154, 154, 153, 153},   // Used for TELEPORTERS as well
     {157, 157, 156, 156, 155, 155, 154, 154},
     {158, 158, 157, 157, 156, 156, 155, 155},
     {159, 159, 158, 158, 157, 157, 156, 156},   
@@ -1342,8 +1342,7 @@ static void AM_drawFline(fline_t * fl, int color)
         case GREENKEY:      DrawWuLine(fl, &(*antialias)[6][0]);  break;
         case BLUEKEY:       DrawWuLine(fl, &(*antialias)[7][0]);  break;
         case SECRETCOLORS:  DrawWuLine(fl, &(*antialias)[8][0]);  break;
-        //case TELEPORTERS:   DrawWuLine(fl, &(*antialias)[9][0]);  break;
-        case EXITS:         DrawWuLine(fl, &(*antialias)[9][0]); break;
+        case EXITS:         DrawWuLine(fl, &(*antialias)[9][0]);  break;
         // IDDT extended colors:
         case IDDT_GREEN:    DrawWuLine(fl, &(*antialias)[10][0]); break;
         case IDDT_YELLOW:   DrawWuLine(fl, &(*antialias)[11][0]); break;

--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -139,11 +139,10 @@ static int m_zoomout;
 // for uncapped framerate and uses different coloring logics:
 // Active monsters: up-up-up-up
 // Inactive monsters: up-down-up-down
-#define IDDT_REDS_RANGE (10)
-#define IDDT_REDS_MIN   (150)
-#define IDDT_REDS_MAX   (150 + IDDT_REDS_RANGE)
-static  int     iddt_reds_active;
-static  int     iddt_reds_inactive = IDDT_REDS_MIN;
+#define IDDT_REDS_RANGE (7)
+#define IDDT_REDS_MIN   (152)
+#define IDDT_REDS_MAX   (IDDT_REDS_MIN + IDDT_REDS_RANGE)
+static  int     iddt_reds = IDDT_REDS_MIN;
 static  boolean iddt_reds_direction = false;
 // [JN] Pulse player arrow in Spectator mode.
 #define ARROW_WHITE_RANGE (10)
@@ -276,7 +275,7 @@ mpoint_t *markpoints = NULL;     // where the points are
 int       markpointnum = 0;      // next point to be assigned (also number of points now)
 int       markpointnum_max = 0;  // killough 2/22/98
 
-#define NUMALIAS      13
+#define NUMALIAS      23
 #define NUMLEVELS     8
 #define INTENSITYBITS 3
 
@@ -291,10 +290,20 @@ static byte antialias_normal[NUMALIAS][NUMLEVELS] = {
     {220, 220, 219, 219, 218, 218, 217, 217},   // GREENKEY
     {197, 197, 196, 196, 195, 195, 194, 194},   // BLUEKEY
     {173, 173, 173, 173, 173, 173, 173, 173},   // SECRETCOLORS
-    {155, 155, 154, 154, 154, 153, 153, 153},   // TELEPORTERS
     {182, 182, 182, 182, 181, 181, 181, 181},   // EXITS
+    // IDDT extended colors
     {224, 224, 223, 223, 222, 222, 221, 221},   // IDDT_GREEN
     {142, 142, 141, 141, 141, 140, 140, 140},   // IDDT_YELLOW
+    {150, 150, 149, 149, 148, 148, 147, 147},   // IDDT_RED
+    {151, 151, 150, 150, 149, 149, 148, 148},
+    {152, 152, 151, 151, 150, 150, 149, 149},
+    {153, 153, 152, 152, 151, 151, 150, 150},
+    {154, 154, 153, 153, 152, 152, 151, 151},
+    {155, 155, 154, 154, 153, 153, 152, 152},
+    {156, 156, 155, 155, 154, 154, 153, 153},
+    {157, 157, 156, 156, 155, 155, 154, 154},
+    {158, 158, 157, 157, 156, 156, 155, 155},
+    {159, 159, 158, 158, 157, 157, 156, 156},    
 };
 
 // [crispy] line colors for map overlay mode
@@ -308,10 +317,20 @@ static byte antialias_overlay[NUMALIAS][NUMLEVELS] = {
     {220, 219, 218, 217, 216, 215, 214, 213},   // GREENKEY
     {197, 197, 196, 196, 195, 195, 194, 194},   // BLUEKEY
     {175, 175, 174, 174, 173, 173, 172, 172},   // SECRETCOLORS
-    {156, 156, 155, 154, 153, 152, 150, 149},   // TELEPORTERS
     {182, 182, 181, 181, 180, 180, 179, 179},   // EXITS
+    // IDDT extended colors
     {224, 223, 222, 221, 220, 219, 218, 217},   // IDDT_GREEN
     {142, 142, 141, 141, 140, 139, 138, 137},   // IDDT_YELLOW
+    {150, 150, 149, 149, 148, 148, 147, 147},   // IDDT_RED
+    {151, 151, 150, 150, 149, 149, 148, 148},
+    {152, 152, 151, 151, 150, 150, 149, 149},
+    {153, 153, 152, 152, 151, 151, 150, 150},
+    {154, 154, 153, 153, 152, 152, 151, 151},
+    {155, 155, 154, 154, 153, 153, 152, 152},
+    {156, 156, 155, 155, 154, 154, 153, 153},
+    {157, 157, 156, 156, 155, 155, 154, 154},
+    {158, 158, 157, 157, 156, 156, 155, 155},
+    {159, 159, 158, 158, 157, 157, 156, 156},   
 };
 
 static byte (*antialias)[NUMALIAS][NUMLEVELS]; // [crispy]
@@ -1075,20 +1094,17 @@ void AM_Ticker (void)
     if (gametic & 1)
     {
         // Brightening
-        if (!iddt_reds_direction && ++iddt_reds_inactive == IDDT_REDS_MAX)
+        if (!iddt_reds_direction && ++iddt_reds == IDDT_REDS_MAX)
         {
             iddt_reds_direction = true;
         }
         // Darkening
         else
-        if (iddt_reds_direction && --iddt_reds_inactive == IDDT_REDS_MIN)
+        if (iddt_reds_direction && --iddt_reds == IDDT_REDS_MIN)
         {
             iddt_reds_direction = false;
         }
     }
-
-    // Active:
-    iddt_reds_active = (IDDT_REDS_MIN) + ((gametic >> 1) % IDDT_REDS_RANGE);
 
     // [JN] Pulse player arrow in Spectator mode:
 
@@ -1326,10 +1342,22 @@ static void AM_drawFline(fline_t * fl, int color)
         case GREENKEY:      DrawWuLine(fl, &(*antialias)[6][0]);  break;
         case BLUEKEY:       DrawWuLine(fl, &(*antialias)[7][0]);  break;
         case SECRETCOLORS:  DrawWuLine(fl, &(*antialias)[8][0]);  break;
-        case TELEPORTERS:   DrawWuLine(fl, &(*antialias)[9][0]);  break;
-        case EXITS:         DrawWuLine(fl, &(*antialias)[10][0]); break;
-        case IDDT_GREEN:    DrawWuLine(fl, &(*antialias)[11][0]); break;
-        case IDDT_YELLOW:   DrawWuLine(fl, &(*antialias)[12][0]); break;
+        //case TELEPORTERS:   DrawWuLine(fl, &(*antialias)[9][0]);  break;
+        case EXITS:         DrawWuLine(fl, &(*antialias)[9][0]); break;
+        // IDDT extended colors:
+        case IDDT_GREEN:    DrawWuLine(fl, &(*antialias)[10][0]); break;
+        case IDDT_YELLOW:   DrawWuLine(fl, &(*antialias)[11][0]); break;
+        case 150:           DrawWuLine(fl, &(*antialias)[12][0]); break;
+        case 151:           DrawWuLine(fl, &(*antialias)[13][0]); break;
+        case 152:           DrawWuLine(fl, &(*antialias)[14][0]); break;
+        case 153:           DrawWuLine(fl, &(*antialias)[15][0]); break;
+        case 154:           DrawWuLine(fl, &(*antialias)[16][0]); break;
+        case 155:           DrawWuLine(fl, &(*antialias)[17][0]); break;
+        case 156:           DrawWuLine(fl, &(*antialias)[18][0]); break;  // Used for TELEPORTERS as well
+        case 157:           DrawWuLine(fl, &(*antialias)[19][0]); break;
+        case 158:           DrawWuLine(fl, &(*antialias)[20][0]); break;
+        case 159:           DrawWuLine(fl, &(*antialias)[21][0]); break;
+        
         default:
         {
             // For debugging only
@@ -2030,8 +2058,6 @@ static void AM_drawThings(int colors, int colorrange)
     mpoint_t  pt;
     mobj_t *t;
     angle_t   actualangle;
-    // RestlessRodent -- Carbon copy from ReMooD
-    int       color = colors;
 
     for (i = 0 ; i < numsectors ; i++)
     {
@@ -2073,20 +2099,11 @@ static void AM_drawThings(int colors, int colorrange)
                 AM_rotatePoint(&pt);
             }
 
-            // [JN] CRL - ReMooD-inspired monsters coloring.
-            if (t->target && t->state && t->state->action != A_Look)
-            {
-                color = iddt_reds_active;
-            }
-            else
-            {
-                color = iddt_reds_inactive;
-            }
-
             AM_drawLineCharacter(thintriangle_guy, NUMTHINTRIANGLEGUYLINES,
                                  actualradius, actualangle,
                                  // Monsters
-                                 t->flags & MF_COUNTKILL ? (t->health > 0 ? color : 15) :
+                                 // [JN] CRL - ReMooD-inspired monsters coloring.
+                                 t->flags & MF_COUNTKILL ? (t->health > 0 ? iddt_reds : 15) :
                                  // Explosive pod (does not have a MF_COUNTKILL flag)
                                  t->type == MT_POD ? IDDT_YELLOW :
                                  // Countable items

--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -276,7 +276,7 @@ mpoint_t *markpoints = NULL;     // where the points are
 int       markpointnum = 0;      // next point to be assigned (also number of points now)
 int       markpointnum_max = 0;  // killough 2/22/98
 
-#define NUMALIAS      11
+#define NUMALIAS      13
 #define NUMLEVELS     8
 #define INTENSITYBITS 3
 
@@ -293,6 +293,8 @@ static byte antialias_normal[NUMALIAS][NUMLEVELS] = {
     {173, 173, 173, 173, 173, 173, 173, 173},   // SECRETCOLORS
     {155, 155, 154, 154, 154, 153, 153, 153},   // TELEPORTERS
     {182, 182, 182, 182, 181, 181, 181, 181},   // EXITS
+    {224, 224, 223, 223, 222, 222, 221, 221},   // IDDT_GREEN
+    {142, 142, 141, 141, 141, 140, 140, 140},   // IDDT_YELLOW
 };
 
 // [crispy] line colors for map overlay mode
@@ -308,6 +310,8 @@ static byte antialias_overlay[NUMALIAS][NUMLEVELS] = {
     {175, 175, 174, 174, 173, 173, 172, 172},   // SECRETCOLORS
     {156, 156, 155, 154, 153, 152, 150, 149},   // TELEPORTERS
     {182, 182, 181, 181, 180, 180, 179, 179},   // EXITS
+    {224, 223, 222, 221, 220, 219, 218, 217},   // IDDT_GREEN
+    {142, 142, 141, 141, 140, 139, 138, 137},   // IDDT_YELLOW
 };
 
 static byte (*antialias)[NUMALIAS][NUMLEVELS]; // [crispy]
@@ -1324,6 +1328,8 @@ static void AM_drawFline(fline_t * fl, int color)
         case SECRETCOLORS:  DrawWuLine(fl, &(*antialias)[8][0]);  break;
         case TELEPORTERS:   DrawWuLine(fl, &(*antialias)[9][0]);  break;
         case EXITS:         DrawWuLine(fl, &(*antialias)[10][0]); break;
+        case IDDT_GREEN:    DrawWuLine(fl, &(*antialias)[11][0]); break;
+        case IDDT_YELLOW:   DrawWuLine(fl, &(*antialias)[12][0]); break;
         default:
         {
             // For debugging only
@@ -2082,9 +2088,9 @@ static void AM_drawThings(int colors, int colorrange)
                                  // Monsters
                                  t->flags & MF_COUNTKILL ? (t->health > 0 ? color : 15) :
                                  // Explosive pod (does not have a MF_COUNTKILL flag)
-                                 t->type == MT_POD ? 141 :
+                                 t->type == MT_POD ? IDDT_YELLOW :
                                  // Countable items
-                                 t->flags & MF_COUNTITEM ? 224 :
+                                 t->flags & MF_COUNTITEM ? IDDT_GREEN :
                                  // Everything else
                                  colors,
                                  pt.x, pt.y);

--- a/src/heretic/am_map.c
+++ b/src/heretic/am_map.c
@@ -628,10 +628,10 @@ void AM_initVariables (void)
 }
 
 // -----------------------------------------------------------------------------
-// AM_clearMarks
+// AM_ClearMarks
 // -----------------------------------------------------------------------------
 
-void AM_clearMarks (void)
+void AM_ClearMarks (void)
 {
     markpointnum = 0;
 }
@@ -917,7 +917,7 @@ boolean AM_Responder (event_t *ev)
             // [JN] Clear all mark by holding "run" button and pressing "clear mark".
             if (speedkeydown())
             {
-                AM_clearMarks();
+                AM_ClearMarks();
                 CT_SetMessage(plr, DEH_String(AMSTR_MARKSCLEARED), false, NULL);
             }
             else
@@ -1637,7 +1637,7 @@ static void AM_drawMline (mline_t *ml, int color)
 // Draws flat (floor/ceiling tile) aligned grid lines.
 // -----------------------------------------------------------------------------
 
-static void AM_drawGrid (int color)
+static void AM_drawGrid (void)
 {
     int64_t x, y;
     int64_t start, end;
@@ -1678,7 +1678,7 @@ static void AM_drawGrid (int color)
             AM_rotatePoint(&ml.a);
             AM_rotatePoint(&ml.b);
         }
-        AM_drawMline(&ml, color);
+        AM_drawMline(&ml, GRIDCOLORS);
     }
 
     // Figure out start of horizontal gridlines
@@ -1715,7 +1715,7 @@ static void AM_drawGrid (int color)
             AM_rotatePoint(&ml.a);
             AM_rotatePoint(&ml.b);
         }
-        AM_drawMline(&ml, color);
+        AM_drawMline(&ml, GRIDCOLORS);
     }
 }
 
@@ -1953,7 +1953,7 @@ static void AM_drawPlayers (void)
     int i;
     mpoint_t  pt;
     player_t *p;
-    static int their_colors[] = { GREENKEY, YELLOWKEY, BLOODRED, BLUEKEY };
+    static int their_colors[] = { PL_GREEN, PL_YELLOW, PL_RED, PL_BLUE };
     int their_color = -1;
     int color;
 
@@ -1982,7 +1982,7 @@ static void AM_drawPlayers (void)
         }
 
         AM_drawLineCharacter(player_arrow, NUMPLYRLINES, 0, smoothangle,
-                             WHITE, pt.x, pt.y);
+                             PL_WHITE, pt.x, pt.y);
         return;
     }
 
@@ -2052,7 +2052,7 @@ static void AM_drawPlayers (void)
 // Draws the things on the automap in double IDDT cheat mode.
 // -----------------------------------------------------------------------------
 
-static void AM_drawThings(int colors, int colorrange)
+static void AM_drawThings(void)
 {
     int i;
     mpoint_t  pt;
@@ -2109,7 +2109,7 @@ static void AM_drawThings(int colors, int colorrange)
                                  // Countable items
                                  t->flags & MF_COUNTITEM ? IDDT_GREEN :
                                  // Everything else
-                                 colors,
+                                 IDDT_GRAY,
                                  pt.x, pt.y);
             t = t->snext;
         }
@@ -2321,7 +2321,7 @@ void AM_Drawer (void)
 
     if (grid)
     {
-        AM_drawGrid(GRIDCOLORS);
+        AM_drawGrid();
     }
 
     AM_drawWalls();
@@ -2330,7 +2330,7 @@ void AM_Drawer (void)
 
     if (ravmap_cheating == 2)
     {
-        AM_drawThings(THINGCOLORS, THINGRANGE);
+        AM_drawThings();
     }
 
     // [JN] CRL - draw pulsing triangle for player in Spectator mode.

--- a/src/heretic/am_map.h
+++ b/src/heretic/am_map.h
@@ -14,43 +14,36 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
-#ifndef __AMMAP_H__
-#define __AMMAP_H__
-
-// For use if I do walls with outsides/insides
-#define REDS		12*8
-#define REDRANGE	1       //16
-#define BLUES		(256-4*16+8)
-#define BLUERANGE	1       //8
-#define GREENS		(33*8)
-#define GREENRANGE	1       //16
-#define GRAYS		(5*8)
-#define GRAYSRANGE	1       //16
-#define BROWNS		(14*8)
-#define BROWNRANGE	1       //16
-#define YELLOWS		10*8
-#define YELLOWRANGE	1
-#define BLACK		0
-#define WHITE		4*8
-#define PARCH		13*8-1
-#define BLOODRED  150
-
-// Automap colors
-#define BACKGROUND	PARCH
-#define YOURCOLORS	WHITE
-#define YOURRANGE	0
-#define WALLRANGE	REDRANGE
-#define THINGCOLORS	GREENS
-#define THINGRANGE	GREENRANGE
-#define SECRETWALLCOLORS WALLCOLORS
-#define SECRETWALLRANGE WALLRANGE
-#define GRIDCOLORS	39// (GRAYS + GRAYSRANGE/2)
-#define GRIDRANGE	0
 
 
+#pragma once
 
 
+typedef struct
+{
+    int64_t x,y;
+} mpoint_t;
 
+extern int ravmap_cheating;
+
+extern mpoint_t *markpoints; 
+extern int markpointnum;
+extern int markpointnum_max;
+
+extern vertex_t KeyPoints[];
+extern const char *LevelNames[];
+
+extern void AM_ClearMarks (void);
+extern void AM_Init (void);
+extern void AM_LevelInit (boolean reinit);
+extern void AM_LevelNameDrawer (void);
+extern void AM_Start (void);
+extern void AM_Stop (void);
+
+
+//
+// Automap colors:
+//
 
 // Common walls
 #define WALLCOLORS      96
@@ -73,35 +66,21 @@
 // Exits
 #define EXITS           182
 
-// IDDT triangles
-#define IDDT_GREEN      222
-#define IDDT_YELLOW     140
-#define IDDT_RED        150
+// Players (no antialiasing)
+#define PL_WHITE        32
+#define PL_GREEN        221
+#define PL_YELLOW       145
+#define PL_RED          160
+#define PL_BLUE         198
 
+// Grid (no antialiasing)
+#define GRIDCOLORS      39
 
 // Crosshair
 #define XHAIRCOLORS	    28
 
-typedef struct
-{
-    int64_t x,y;
-} mpoint_t;
-
-extern int ravmap_cheating;
-
-extern mpoint_t *markpoints; 
-extern int markpointnum;
-extern int markpointnum_max;
-
-extern vertex_t KeyPoints[];
-extern const char *LevelNames[];
-
-void AM_Stop(void);
-
-extern void AM_Init (void);
-extern void AM_Start (void);
-extern void AM_LevelInit (boolean reinit);
-extern void AM_LevelNameDrawer (void);
-extern void AM_clearMarks (void);
-
-#endif
+// IDDT triangles
+#define IDDT_GREEN      222
+#define IDDT_YELLOW     140
+#define IDDT_RED        150
+#define IDDT_GRAY       9

--- a/src/heretic/am_map.h
+++ b/src/heretic/am_map.h
@@ -76,6 +76,8 @@
 // IDDT triangles
 #define IDDT_GREEN      222
 #define IDDT_YELLOW     140
+#define IDDT_RED        150
+
 
 // Crosshair
 #define XHAIRCOLORS	    28

--- a/src/heretic/am_map.h
+++ b/src/heretic/am_map.h
@@ -73,6 +73,10 @@
 // Exits
 #define EXITS           182
 
+// IDDT triangles
+#define IDDT_GREEN      222
+#define IDDT_YELLOW     140
+
 // Crosshair
 #define XHAIRCOLORS	    28
 

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -2154,7 +2154,7 @@ void G_DoWorldDone(void)
     G_DoLoadLevel();
     gameaction = ga_nothing;
     // [JN] jff 4/12/98 clear any marks on the automap
-    AM_clearMarks();
+    AM_ClearMarks();
 }
 
 //---------------------------------------------------------------------------
@@ -2367,7 +2367,7 @@ void G_InitNew(skill_t skill, int episode, int map)
     // https://doomwiki.org/wiki/Automap_scale_preserved_after_warps_in_Heretic_and_Hexen
     automapactive = false; 
     // [JN] jff 4/16/98 force marks on automap cleared every new level start
-    AM_clearMarks();
+    AM_ClearMarks();
     gameepisode = episode;
     gamemap = map;
     gameskill = skill;
@@ -2379,9 +2379,6 @@ void G_InitNew(skill_t skill, int episode, int map)
     finalintermission = false;
 
     defdemotics = 0;
-
-    // [JN] jff 4/16/98 force marks on automap cleared every new level start
-    AM_clearMarks();
 
     // Set the sky map
     if (episode > 5)
@@ -2426,7 +2423,7 @@ void G_DoSelectiveGame (int choice)
     // [crispy] reset game speed after demo fast-forward
     singletics = false;
     // [JN] jff 4/16/98 force marks on automap cleared every new level start
-    AM_clearMarks();
+    AM_ClearMarks();
     playeringame[1] = playeringame[2] = playeringame[3] = 0;
     consoleplayer = 0;
     gameaction = ga_nothing;


### PR DESCRIPTION
* Apply antialiasing for green (items), yellow (gasbags) and red (monsters) `IDDT` triangles for better visibility.
* Slightly simplified ReMood-inspired pulse. Not looking very good in non-overlayed background.
* Small cleanup and code simplification.