### PR TITLE
Call HSV colors initialization only once

### DIFF
--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -1245,13 +1245,20 @@ void R_InitColormaps (void)
 
 	W_ReleaseLumpName("COLORMAP");
 #endif
+}
 
-    // [crispy] initialize color translation and color strings tables
-    {
+
+//
+// R_InitHSVColors
+// [crispy] initialize color translation and color strings tables
+//
+static void R_InitHSVColors (void)
+{
 	byte *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
 	char c[3];
 	int i, j;
 	boolean keepgray = false;
+	const int starttime = I_GetTimeMS();
 
 	if (!crstr)
 	    crstr = I_Realloc(NULL, CRMAX * sizeof(*crstr));
@@ -1287,9 +1294,8 @@ void R_InitColormaps (void)
 	{
 	    cr[CR_RED2BLUE] = W_CacheLumpNum(i, PU_STATIC);
 	}
-    }
+	printf("\nR_InitHSVColors took %d ms.\n", I_GetTimeMS() - starttime);
 }
-
 
 
 //
@@ -1314,6 +1320,8 @@ void R_InitData (void)
     R_InitSpriteLumps ();
     printf (".");
     R_InitColormaps ();
+    printf (".");    
+    R_InitHSVColors ();
     printf (".");    
 #ifndef CRISPY_TRUECOLOR
     // [JN] Compose translucency tables.

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -1258,7 +1258,6 @@ static void R_InitHSVColors (void)
 	char c[3];
 	int i, j;
 	boolean keepgray = false;
-	const int starttime = I_GetTimeMS();
 
 	if (!crstr)
 	    crstr = I_Realloc(NULL, CRMAX * sizeof(*crstr));
@@ -1294,7 +1293,6 @@ static void R_InitHSVColors (void)
 	{
 	    cr[CR_RED2BLUE] = W_CacheLumpNum(i, PU_STATIC);
 	}
-	printf("\nR_InitHSVColors took %d ms.\n", I_GetTimeMS() - starttime);
 }
 
 

--- a/src/heretic/r_data.c
+++ b/src/heretic/r_data.c
@@ -703,31 +703,45 @@ void R_InitColormaps(void)
 
 	W_ReleaseLumpName("COLORMAP");
 #endif
-    // [crispy] initialize color translation and color strings tables
+}
+
+
+/*
+================
+=
+= R_InitHSVColors
+=
+= [crispy] initialize color translation and color strings tables
+=
+=================
+*/
+
+static void R_InitHSVColors (void)
+{
+    byte *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
+    char c[3];
+    int i, j;
+    const int starttime = I_GetTimeMS();
+
+    if (!crstr)
     {
-        byte *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
-        char c[3];
-        int i, j;
-
-        if (!crstr)
-        {
-            crstr = realloc(NULL, CRMAX * sizeof(*crstr));
-        }
-
-        // [JN] TODO - get rid of -2
-        for (i = 0 ; i < CRMAX-2 ; i++)
-        {
-            for (j = 0; j < 256; j++)
-            {
-                cr[i][j] = V_Colorize(playpal, i, j, false);
-            }
-
-            M_snprintf(c, sizeof(c), "%c%c", cr_esc, '0' + i);
-            crstr[i] = M_StringDuplicate(c);
-        }
-
-        W_ReleaseLumpName("PLAYPAL");
+        crstr = realloc(NULL, CRMAX * sizeof(*crstr));
     }
+
+    // [JN] TODO - get rid of -2
+    for (i = 0 ; i < CRMAX-2 ; i++)
+    {
+        for (j = 0; j < 256; j++)
+        {
+            cr[i][j] = V_Colorize(playpal, i, j, false);
+        }
+
+        M_snprintf(c, sizeof(c), "%c%c", cr_esc, '0' + i);
+        crstr[i] = M_StringDuplicate(c);
+    }
+
+    W_ReleaseLumpName("PLAYPAL");
+	printf("\nR_InitHSVColors took %d ms.\n", I_GetTimeMS() - starttime);
 }
 
 #ifdef CRISPY_TRUECOLOR
@@ -784,6 +798,8 @@ void R_InitData(void)
     //IncThermo();
     printf (".");
     R_InitColormaps();
+    printf (".");
+    R_InitHSVColors();
     printf (".");
 #ifndef CRISPY_TRUECOLOR
     // [JN] Load original TINTTAB lump.

--- a/src/heretic/r_data.c
+++ b/src/heretic/r_data.c
@@ -721,7 +721,6 @@ static void R_InitHSVColors (void)
     byte *playpal = W_CacheLumpName("PLAYPAL", PU_STATIC);
     char c[3];
     int i, j;
-    const int starttime = I_GetTimeMS();
 
     if (!crstr)
     {
@@ -741,7 +740,6 @@ static void R_InitHSVColors (void)
     }
 
     W_ReleaseLumpName("PLAYPAL");
-	printf("\nR_InitHSVColors took %d ms.\n", I_GetTimeMS() - starttime);
 }
 
 #ifdef CRISPY_TRUECOLOR


### PR DESCRIPTION
This is have to be done only once at program startup, as HSV tables are not related to colormaps and gamma correction.
Little optimization to save about `5` milliseconds on gamma-correction and few other features toggling.