### PR TITLE
Heretic: missing break from serpent torch brightmap

### DIFF
--- a/src/heretic/r_bmaps.c
+++ b/src/heretic/r_bmaps.c
@@ -369,6 +369,7 @@ const byte *R_BrightmapForSprite (const int state)
             case S_SERPTORCH3:
             {
                 return serptorch;
+                break;
             }
             // Iron Lich (idle and attack states)
             case S_HEAD_LOOK:


### PR DESCRIPTION
oops. I guess this isn't technically necessary, but for consistency.