### PR TITLE
Hexen: Extra Translucency feature

### DIFF
--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -295,6 +295,8 @@ typedef struct
 #define	MF_TRANSLATION	0x1c000000      // use a translation table (>>MF_TRANSHIFT)
 #define	MF_TRANSSHIFT	26      // table for player colormaps
 
+#define MF_EXTRATRANS   (int)0x40000000  // [JN] Extra translucecy
+#define MF_FLIPPABLE    (int)0x80000000  // [crispy] randomly flip corpse, blood and death animation sprites
 
 // --- mobj.flags2 ---
 

--- a/src/hexen/info.c
+++ b/src/hexen/info.c
@@ -4361,7 +4361,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      1,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (explosion of Porkalator missile)
      MF2_NOTELEPORT             // flags2
      },
 
@@ -8978,7 +8979,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY |      // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (red flash of teleport)
      0                          // flags2
      },
 
@@ -9005,7 +9007,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY |      // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (red fog of teleport)
      0                          // flags2
      },
 
@@ -9140,7 +9143,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY |      // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Timon's axe blue flash)
      0                          // flags2
      },
 
@@ -9221,7 +9225,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      10,                        // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY |    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_FIREDAMAGE  // flags2
      },
 
@@ -9275,7 +9279,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      8,                         // damage
      SFX_NONE,                  // activesound
-     MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF,    // flags
+     MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Quietus big green smoke)
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS   // flags2
      },
 
@@ -9356,7 +9361,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      5,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Serpent Staff missile)
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS   // flags2
      },
 
@@ -9518,7 +9524,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      2,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Firestorm small flames, appearing on impact only)
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
 
@@ -9545,7 +9552,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      8,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Firestorm big flame)
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_DONTDRAW | MF2_FIREDAMAGE   // flags2
      },
 
@@ -9761,7 +9769,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      2,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Sapphire want missile)
      MF2_NOTELEPORT | MF2_RIP | MF2_IMPACT | MF2_PCROSS | MF2_NODMGTHRUST | MF2_CANNOTPUSH      // flags2
      },
 
@@ -9815,7 +9824,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      8,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF,    // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Arc of Death top lightning)
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS   // flags2
      },
 
@@ -9842,7 +9852,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      8,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF,    // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Arc of Death bottom lightning)
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS   // flags2
      },
 
@@ -9869,7 +9880,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      2,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF,    // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Arc of Death middle lightning)
      0                          // flags2
      },
 
@@ -9896,7 +9908,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      6,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY |    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE | MF2_RIP | MF2_IMPACT | MF2_PCROSS        // flags2
      },
 
@@ -9923,7 +9935,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      4,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Bloodscourge explosion)
      MF2_NOTELEPORT | MF2_FIREDAMAGE | MF2_IMPACT | MF2_PCROSS | MF2_SEEKERMISSILE      // flags2
      },
 
@@ -10247,7 +10260,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      1,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Frost Shards missile and puff)
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_ICEDAMAGE   // flags2
      },
 
@@ -10625,7 +10639,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      4,                         // damage
      SFX_NONE,                  // activesound
-     MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF,    // flags
+     MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Slaugtaur missile)
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS   // flags2
      },
 
@@ -10868,7 +10883,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      5,                         // damage
      SFX_NONE,                  // activesound
-     MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF,    // flags
+     MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Green Chaos Seprent fireball)
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_FIREDAMAGE  // flags2
      },
 
@@ -11138,7 +11154,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      5,                         // mass
      5,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF | MF_MISSILE,    // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF | MF_MISSILE |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Reiver fireball)
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_FLOORCLIP | MF2_FIREDAMAGE  // flags2
      },
 
@@ -11732,7 +11749,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      1,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Dark Bishop missile)
      MF2_NOTELEPORT | MF2_SEEKERMISSILE // flags2
      },
 
@@ -11786,7 +11804,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      6,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Death Wyvern fireball)
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
 
@@ -12650,7 +12669,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      15,                        // mass
      1,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF | MF_MISSILE,    // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF | MF_MISSILE |    // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Affrit fireballs)
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_FLOORCLIP | MF2_FIREDAMAGE  // flags2
      },
 
@@ -13055,7 +13075,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE,        // flags
+     MF_NOBLOCKMAP | MF_MISSILE |        // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Heresiarch attack)
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
 
@@ -13082,7 +13103,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
+     MF_NOBLOCKMAP | MF_NOGRAVITY |      // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Heresiarch attack)
      MF2_NOTELEPORT             // flags2
      },
 
@@ -13136,7 +13158,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE,        // flags
+     MF_NOBLOCKMAP | MF_MISSILE |        // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Heresiarch attack)
      MF2_NOTELEPORT             // flags2
      },
 
@@ -13190,7 +13213,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_MISSILE | MF_NOGRAVITY, // flags
+     MF_NOBLOCKMAP | MF_MISSILE | MF_NOGRAVITY | // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Heresiarch attack)
      MF2_NOTELEPORT             // flags2
      },
 
@@ -13217,7 +13241,8 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
      100,                       // mass
      0,                         // damage
      SFX_NONE,                  // activesound
-     MF_NOBLOCKMAP | MF_DROPOFF,        // flags
+     MF_NOBLOCKMAP | MF_DROPOFF |        // flags
+     MF_EXTRATRANS,             // [JN] Extra translucency (Heresiarch attack)
      MF2_NOTELEPORT | MF2_LOGRAV        // flags2
      },
 

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -2812,12 +2812,10 @@ static void M_Draw_ID_Gameplay_1 (void)
                M_Item_Glow(0, vis_brightmaps ? GLOW_GREEN : GLOW_DARKRED));
 
     // Translucency
-    /*
     sprintf(str, vis_translucency == 1 ? "ADDITIVE" :
                  vis_translucency == 2 ? "BLENDING" : "OFF");
     MN_DrTextA(str, M_ItemRightAlign(str), 30,
                M_Item_Glow(1, vis_translucency ? GLOW_GREEN : GLOW_DARKRED));
-    */
 
     // Diminished lighting
     sprintf(str, vis_smooth_light ? "SMOOTH" : "ORIGINAL");
@@ -2884,9 +2882,7 @@ static void M_ID_Brightmaps (int choice)
 
 static void M_ID_Translucency (int choice)
 {
-    /*
     vis_translucency = M_INT_Slider(vis_translucency, 0, 2, choice, false);
-    */
 }
 
 static void M_ID_SmoothLightingHook (void)

--- a/src/hexen/r_local.h
+++ b/src/hexen/r_local.h
@@ -408,6 +408,7 @@ extern int detailshift;         // 0 = high, 1 = low
 extern void (*colfunc) (void);
 extern void (*basecolfunc) (void);
 extern void (*tlcolfunc) (void);
+extern void (*extratlcolfunc) (void);
 extern void (*spanfunc) (void);
 
 // [crispy] smooth texture scrolling
@@ -605,6 +606,8 @@ void R_DrawTranslatedTLColumn(void);
 void R_DrawTranslatedColumnLow(void);
 void R_DrawAltTLColumn(void);
 //void  R_DrawTranslatedAltTLColumn(void);
+void R_DrawExtraTLColumn(void);
+void R_DrawExtraTLColumnLow(void);
 
 extern int ds_y;
 extern int ds_x1;

--- a/src/hexen/r_main.c
+++ b/src/hexen/r_main.c
@@ -94,6 +94,7 @@ void (*colfunc) (void);
 void (*basecolfunc) (void);
 void (*tlcolfunc) (void);
 void (*transcolfunc) (void);
+void (*extratlcolfunc) (void);
 void (*spanfunc) (void);
 
 void SB_ForceRedraw(void); // [crispy] sb_bar.c
@@ -736,6 +737,7 @@ void R_ExecuteSetViewSize(void)
         colfunc = basecolfunc = R_DrawColumn;
         tlcolfunc = R_DrawTLColumn;
         transcolfunc = R_DrawTranslatedColumn;
+        extratlcolfunc = R_DrawExtraTLColumn;
         spanfunc = R_DrawSpan;
     }
     else
@@ -743,6 +745,7 @@ void R_ExecuteSetViewSize(void)
         colfunc = basecolfunc = R_DrawColumnLow;
         tlcolfunc = R_DrawTLColumn;
         transcolfunc = R_DrawTranslatedColumn;
+        extratlcolfunc = R_DrawExtraTLColumnLow;
         spanfunc = R_DrawSpanLow;
     }
 

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -441,6 +441,13 @@ void R_DrawVisSprite(vissprite_t * vis, int x1, int x2)
             ((vis->mobjflags & MF_TRANSLATION) >> (MF_TRANSSHIFT - 8));
     }
 
+    if (vis->mobjflags & MF_EXTRATRANS && vis_translucency)
+    {
+        // [JN] Extra translucency feature.
+        colfunc = extratlcolfunc;
+        blendfunc = vis->blendfunc;
+    }
+
     dc_iscale = abs(vis->xiscale) >> detailshift;
     dc_texturemid = vis->texturemid;
     frac = vis->startfrac;
@@ -693,6 +700,19 @@ void R_ProjectSprite(mobj_t * thing)
         vis->blendfunc = I_BlendOverAltTinttab;
     }
 #endif
+
+    // [JN] Extra translucency. Draw full bright sprites with 
+    // different functions, depending on user's choice.
+    if (thing->flags & MF_EXTRATRANS)
+    {
+        vis->blendfunc = 
+            (thing->frame & FF_FULLBRIGHT) ? (vis_translucency == 1 ?
+#ifndef CRISPY_TRUECOLOR
+            addmap : tintmap) : tintmap;
+#else
+            I_BlendAdd : I_BlendOverExtra) : I_BlendOverExtra;
+#endif
+    }
 }
 
 


### PR DESCRIPTION
Same to Heretic, this makes previously opaque sprites translucent. There is probably some potential for extra object left, but it need normal playtesting.