### PR TITLE
Hexen: class-based armor and sfx attenuation features

### DIFF
--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -390,7 +390,6 @@ typedef struct pspdef_s
     state_t *state;             // a NULL state means not active
     int tics;
     fixed_t sx, sy;
-    fixed_t sx2, sy2; // [crispy] variable weapon sprite bob
 } pspdef_t;
 
 /* Old Heretic key type

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -551,12 +551,17 @@ static void M_ID_LinearSky (int choice);
 static void M_ID_FlipCorpses (int choice);
 static void M_ID_Crosshair (int choice);
 static void M_ID_CrosshairColor (int choice);
-static void M_ID_ColoredSBar (int choice);
-static void M_ID_WeaponWidget (int choice);
 
 static void M_Draw_ID_Gameplay_2 (void);
+static void M_ID_ColoredSBar (int choice);
+static void M_ID_WeaponWidget (int choice);
+static void M_ID_ArmorIcon (int choice);
+static void M_ID_ZAxisSfx (int choice);
 static void M_ID_Torque (int choice);
+static void M_ID_WeaponAlignment (int choice);
 static void M_ID_Breathing (int choice);
+
+static void M_Draw_ID_Gameplay_3 (void);
 static void M_ID_DefaultClass (int choice);
 static void M_ID_DefaultSkill (int choice);
 static void M_ID_FlipLevels (int choice);
@@ -565,8 +570,6 @@ static void M_ID_DemoTimer (int choice);
 static void M_ID_TimerDirection (int choice);
 static void M_ID_ProgressBar (int choice);
 static void M_ID_InternalDemos (int choice);
-
-static void M_Draw_ID_Gameplay_3 (void);
 
 static void M_ID_SettingReset (int choice);
 static void M_ID_ApplyReset (void);
@@ -2839,8 +2842,7 @@ static MenuItem_t ID_Menu_Gameplay_1[] = {
     { ITT_LRFUNC,  "SHAPE",                       M_ID_Crosshair,       0, MENU_NONE         },
     { ITT_LRFUNC,  "INDICATION",                  M_ID_CrosshairColor,  0, MENU_NONE         },
     { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
-    { ITT_LRFUNC,  "COLORED ELEMENTS",            M_ID_ColoredSBar,     0, MENU_NONE         },
-    { ITT_LRFUNC,  "4TH WEAPON WIDGET",           M_ID_WeaponWidget,    0, MENU_NONE         },
+    { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
     { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
     { ITT_SETMENU, "", /* NEXT PAGE */            NULL,                 0, MENU_ID_GAMEPLAY2 },
 };
@@ -2848,7 +2850,7 @@ static MenuItem_t ID_Menu_Gameplay_1[] = {
 static Menu_t ID_Def_Gameplay_1 = {
     ID_MENU_LEFTOFFSET, ID_MENU_TOPOFFSET,
     M_Draw_ID_Gameplay_1,
-    14, ID_Menu_Gameplay_1,
+    13, ID_Menu_Gameplay_1,
     0,
     true, false, true,
     MENU_ID_MAIN
@@ -2913,25 +2915,12 @@ static void M_Draw_ID_Gameplay_1 (void)
                M_Item_Glow(8, !xhair_draw ? GLOW_DARKRED :
                                xhair_color ? GLOW_GREEN : GLOW_DARKRED));
 
-    MN_DrTextACentered("STATUS BAR", 110, cr[CR_YELLOW]);
-
-    // Colored elements
-    sprintf(str, st_colored_stbar ? "ON" : "OFF");
-    MN_DrTextA(str, M_ItemRightAlign(str), 120,
-               M_Item_Glow(10, st_colored_stbar ? GLOW_GREEN : GLOW_DARKRED));
-
-    // Fourth weapon widget
-    sprintf(str, st_weapon_widget == 1 ? "SOLID" :
-                 st_weapon_widget == 2 ? "TRANSLUCENT" : "OFF");
-    MN_DrTextA(str, M_ItemRightAlign(str), 130,
-               M_Item_Glow(11, st_weapon_widget ? GLOW_GREEN : GLOW_DARKRED));
-
-    MN_DrTextA("NEXT PAGE", ID_MENU_LEFTOFFSET, 150,
-               M_Item_Glow(13, GLOW_DARKGRAY));
+    MN_DrTextA("NEXT PAGE", ID_MENU_LEFTOFFSET, 140,
+               M_Item_Glow(12, GLOW_DARKGRAY));
 
     // Footer
     sprintf(str, "PAGE 1/3");
-    MN_DrTextA(str, M_ItemRightAlign(str), 150, M_Item_Glow(13, GLOW_DARKGRAY));
+    MN_DrTextA(str, M_ItemRightAlign(str), 140, M_Item_Glow(12, GLOW_DARKGRAY));
 }
 
 static void M_ID_Brightmaps (int choice)
@@ -2985,41 +2974,30 @@ static void M_ID_CrosshairColor (int choice)
     xhair_color = M_INT_Slider(xhair_color, 0, 3, choice, false);
 }
 
-static void M_ID_ColoredSBar (int choice)
-{
-    st_colored_stbar ^= 1;
-}
-
-static void M_ID_WeaponWidget (int choice)
-{
-    st_weapon_widget = M_INT_Slider(st_weapon_widget, 0, 2, choice, false);
-}
-
 // -----------------------------------------------------------------------------
 // Gameplay features 2
 // -----------------------------------------------------------------------------
 
 static MenuItem_t ID_Menu_Gameplay_2[] = {
-    { ITT_LRFUNC,  "CORPSES SLIDING FROM LEDGES", M_ID_Torque,         0, MENU_NONE         },
-    { ITT_LRFUNC,  "IMITATE PLAYER'S BREATHING",  M_ID_Breathing,      0, MENU_NONE         },
-    { ITT_EMPTY,   NULL,                          NULL,                0, MENU_NONE         },
-    { ITT_LRFUNC,  "DEFAULT PLAYER CLASS",        M_ID_DefaultClass,   0, MENU_NONE         },
-    { ITT_LRFUNC,  "DEFAULT SKILL LEVEL",         M_ID_DefaultSkill,   0, MENU_NONE         },
-    { ITT_LRFUNC,  "FLIP LEVELS HORIZONTALLY",    M_ID_FlipLevels,     0, MENU_NONE         },
-    { ITT_LRFUNC,  "ON DEATH ACTION",             M_ID_OnDeathAction,  0, MENU_NONE         },
-    { ITT_EMPTY,   NULL,                          NULL,                0, MENU_NONE         },
-    { ITT_LRFUNC,  "SHOW DEMO TIMER",             M_ID_DemoTimer,      0, MENU_NONE         },
-    { ITT_LRFUNC,  "TIMER DIRECTION",             M_ID_TimerDirection, 0, MENU_NONE         },
-    { ITT_LRFUNC,  "SHOW PROGRESS BAR",           M_ID_ProgressBar,    0, MENU_NONE         },
-    { ITT_LRFUNC,  "PLAY INTERNAL DEMOS",         M_ID_InternalDemos,  0, MENU_NONE         },
-    { ITT_EMPTY,   NULL,                          NULL,                0, MENU_NONE         },
-    { ITT_SETMENU, "", /* LAST PAGE */            NULL,                0, MENU_ID_GAMEPLAY3 },
+    { ITT_LRFUNC,  "COLORED ELEMENTS",            M_ID_ColoredSBar,     0, MENU_NONE         },
+    { ITT_LRFUNC,  "4TH WEAPON WIDGET",           M_ID_WeaponWidget,    0, MENU_NONE         },
+    { ITT_LRFUNC,  "ARMOR ICON",                  M_ID_ArmorIcon,       0, MENU_NONE         },
+    { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
+    { ITT_LRFUNC,  "SFX ATTENUATION AXISES",      M_ID_ZAxisSfx,        0, MENU_NONE         },
+    { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
+    { ITT_LRFUNC,  "CORPSES SLIDING FROM LEDGES", M_ID_Torque,          0, MENU_NONE         },
+    { ITT_LRFUNC,  "WEAPON ATTACK ALIGNMENT",     M_ID_WeaponAlignment, 0, MENU_NONE         },
+    { ITT_LRFUNC,  "IMITATE PLAYER'S BREATHING",  M_ID_Breathing,       0, MENU_NONE         },
+    { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
+    { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
+    { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
+    { ITT_SETMENU, "", /* LAST PAGE */            NULL,                 0, MENU_ID_GAMEPLAY3 },
 };
 
 static Menu_t ID_Def_Gameplay_2 = {
     ID_MENU_LEFTOFFSET, ID_MENU_TOPOFFSET,
     M_Draw_ID_Gameplay_2,
-    14, ID_Menu_Gameplay_2,
+    13, ID_Menu_Gameplay_2,
     0,
     true, false, true,
     MENU_ID_MAIN
@@ -3030,72 +3008,82 @@ static void M_Draw_ID_Gameplay_2 (void)
     char str[32];
     Gameplay_Cur = (MenuType_t)MENU_ID_GAMEPLAY2;
 
-    MN_DrTextACentered("PHYSICAL", 10, cr[CR_YELLOW]);
+    MN_DrTextACentered("STATUS BAR", 10, cr[CR_YELLOW]);
+
+    // Colored elements
+    sprintf(str, st_colored_stbar ? "ON" : "OFF");
+    MN_DrTextA(str, M_ItemRightAlign(str), 20,
+               M_Item_Glow(0, st_colored_stbar ? GLOW_GREEN : GLOW_DARKRED));
+
+    // Fourth weapon widget
+    sprintf(str, st_weapon_widget == 1 ? "SOLID" :
+                 st_weapon_widget == 2 ? "TRANSLUCENT" : "OFF");
+    MN_DrTextA(str, M_ItemRightAlign(str), 30,
+               M_Item_Glow(1, st_weapon_widget ? GLOW_GREEN : GLOW_DARKRED));
+
+    // Armor icon
+    /*
+    sprintf(str, st_weapon_widget == 1 ? "SOLID" :
+                 st_weapon_widget == 2 ? "TRANSLUCENT" : "OFF");
+    MN_DrTextA(str, M_ItemRightAlign(str), 40,
+               M_Item_Glow(2, st_weapon_widget ? GLOW_GREEN : GLOW_DARKRED));
+    */
+
+    MN_DrTextACentered("AUDIBLE", 50, cr[CR_YELLOW]);
+
+    // Sfx Attenuation Axises
+    /*
+    sprintf(str, st_weapon_widget == 1 ? "SOLID" :
+                 st_weapon_widget == 2 ? "TRANSLUCENT" : "OFF");
+    MN_DrTextA(str, M_ItemRightAlign(str), 60,
+               M_Item_Glow(4, st_weapon_widget ? GLOW_GREEN : GLOW_DARKRED));
+    */
+
+    MN_DrTextACentered("PHYSICAL", 70, cr[CR_YELLOW]);
 
     // Corpses sliding from ledges
     sprintf(str, phys_torque ? "ON" : "OFF");
-    MN_DrTextA(str, M_ItemRightAlign(str), 20,
-               M_Item_Glow(0, phys_torque ? GLOW_GREEN : GLOW_DARKRED));
+    MN_DrTextA(str, M_ItemRightAlign(str), 80,
+               M_Item_Glow(6, phys_torque ? GLOW_GREEN : GLOW_DARKRED));
+
+    // Weapon attack alignment
+    /*
+    sprintf(str, phys_torque ? "ON" : "OFF");
+    MN_DrTextA(str, M_ItemRightAlign(str), 90,
+               M_Item_Glow(7, phys_torque ? GLOW_GREEN : GLOW_DARKRED));
+    */
 
     // Imitate player's breathing
     sprintf(str, phys_breathing ? "ON" : "OFF");
-    MN_DrTextA(str, M_ItemRightAlign(str), 30,
-               M_Item_Glow(1, phys_breathing ? GLOW_GREEN : GLOW_DARKRED));
-
-    MN_DrTextACentered("GAMEPLAY", 40, cr[CR_YELLOW]);
-
-    // Default player class
-    M_snprintf(str, sizeof(str), "%s", DefClassName[gp_default_class]);
-    MN_DrTextA(str, M_ItemRightAlign(str), 50,
-               M_Item_Glow(3, gp_default_class == 0 ? GLOW_GREEN :
-                              gp_default_class == 1 ? GLOW_BLUE : GLOW_RED));
-
-    // Default skill level
-    M_snprintf(str, sizeof(str), "%s", DefSkillName[gp_default_skill]);
-    MN_DrTextA(str, M_ItemRightAlign(str), 60,
-               DefSkillColor(gp_default_skill));
-
-    // Flip levels horizontally
-    sprintf(str, gp_flip_levels ? "ON" : "OFF");
-    MN_DrTextA(str, M_ItemRightAlign(str), 70,
-               M_Item_Glow(5, gp_flip_levels ? GLOW_GREEN : GLOW_DARKRED));
-
-    // On death action
-    sprintf(str, gp_death_use_action == 1 ? "LAST SAVE" :
-                 gp_death_use_action == 2 ? "NOTHING" : "DEFAULT");
-    MN_DrTextA(str, M_ItemRightAlign(str), 80,
-               M_Item_Glow(6, gp_death_use_action ? GLOW_GREEN : GLOW_DARKRED));
-
-    MN_DrTextACentered("DEMOS", 90, cr[CR_YELLOW]);
-
-    // Show Demo timer
-    sprintf(str, demo_timer == 1 ? "PLAYBACK" : 
-                 demo_timer == 2 ? "RECORDING" : 
-                 demo_timer == 3 ? "ALWAYS" : "OFF");
     MN_DrTextA(str, M_ItemRightAlign(str), 100,
-               M_Item_Glow(8, demo_timer ? GLOW_GREEN : GLOW_DARKRED));
+               M_Item_Glow(8, phys_breathing ? GLOW_GREEN : GLOW_DARKRED));
 
-    // Timer direction
-    sprintf(str, demo_timerdir ? "BACKWARD" : "FORWARD");
-    MN_DrTextA(str, M_ItemRightAlign(str), 110,
-               M_Item_Glow(9, demo_timer ? GLOW_GREEN : GLOW_DARKRED));
-
-    // Show progress bar
-    sprintf(str, demo_bar ? "ON" : "OFF");
-    MN_DrTextA(str, M_ItemRightAlign(str), 120,
-               M_Item_Glow(10, demo_bar ? GLOW_GREEN : GLOW_DARKRED));
-
-    // Play internal demos
-    sprintf(str, demo_internal ? "ON" : "OFF");
-    MN_DrTextA(str, M_ItemRightAlign(str), 130,
-               M_Item_Glow(11, demo_internal ? GLOW_DARKRED : GLOW_GREEN));
-
-    MN_DrTextA("LAST PAGE", ID_MENU_LEFTOFFSET, 150,
-               M_Item_Glow(13, GLOW_DARKGRAY));
+    MN_DrTextA("LAST PAGE", ID_MENU_LEFTOFFSET, 140,
+               M_Item_Glow(12, GLOW_DARKGRAY));
 
     // Footer
     sprintf(str, "PAGE 2/3");
-    MN_DrTextA(str, M_ItemRightAlign(str), 150, M_Item_Glow(13, GLOW_DARKGRAY));
+    MN_DrTextA(str, M_ItemRightAlign(str), 140, M_Item_Glow(12, GLOW_DARKGRAY));
+}
+
+static void M_ID_ColoredSBar (int choice)
+{
+    st_colored_stbar ^= 1;
+}
+
+static void M_ID_WeaponWidget (int choice)
+{
+    st_weapon_widget = M_INT_Slider(st_weapon_widget, 0, 2, choice, false);
+}
+
+static void M_ID_ArmorIcon (int choice)
+{
+    // phys_torque ^= 1;
+}
+
+static void M_ID_ZAxisSfx (int choice)
+{
+    // phys_torque ^= 1;
 }
 
 static void M_ID_Torque (int choice)
@@ -3103,9 +3091,104 @@ static void M_ID_Torque (int choice)
     phys_torque ^= 1;
 }
 
+static void M_ID_WeaponAlignment (int choice)
+{
+    // phys_torque ^= 1;
+}
+
 static void M_ID_Breathing (int choice)
 {
     phys_breathing ^= 1;
+}
+
+// -----------------------------------------------------------------------------
+// Gameplay features 3
+// -----------------------------------------------------------------------------
+
+static MenuItem_t ID_Menu_Gameplay_3[] = {
+    { ITT_LRFUNC,  "DEFAULT PLAYER CLASS",        M_ID_DefaultClass,   0, MENU_NONE         },
+    { ITT_LRFUNC,  "DEFAULT SKILL LEVEL",         M_ID_DefaultSkill,   0, MENU_NONE         },
+    { ITT_LRFUNC,  "FLIP LEVELS HORIZONTALLY",    M_ID_FlipLevels,     0, MENU_NONE         },
+    { ITT_LRFUNC,  "ON DEATH ACTION",             M_ID_OnDeathAction,  0, MENU_NONE         },
+    { ITT_EMPTY,   NULL,                          NULL,                0, MENU_NONE         },
+    { ITT_LRFUNC,  "SHOW DEMO TIMER",             M_ID_DemoTimer,      0, MENU_NONE         },
+    { ITT_LRFUNC,  "TIMER DIRECTION",             M_ID_TimerDirection, 0, MENU_NONE         },
+    { ITT_LRFUNC,  "SHOW PROGRESS BAR",           M_ID_ProgressBar,    0, MENU_NONE         },
+    { ITT_LRFUNC,  "PLAY INTERNAL DEMOS",         M_ID_InternalDemos,  0, MENU_NONE         },
+    { ITT_EMPTY,   NULL,                          NULL,                0, MENU_NONE         },
+    { ITT_EMPTY,   NULL,                          NULL,                0, MENU_NONE         },
+    { ITT_EMPTY,   NULL,                          NULL,                0, MENU_NONE         },
+    { ITT_SETMENU, "", /* FIRST PAGE */           NULL,                0, MENU_ID_GAMEPLAY1 },
+};
+
+static Menu_t ID_Def_Gameplay_3 = {
+    ID_MENU_LEFTOFFSET, ID_MENU_TOPOFFSET,
+    M_Draw_ID_Gameplay_3,
+    13, ID_Menu_Gameplay_3,
+    0,
+    true, false, true,
+    MENU_ID_MAIN
+};
+
+static void M_Draw_ID_Gameplay_3 (void)
+{
+    char str[32];
+    Gameplay_Cur = (MenuType_t)MENU_ID_GAMEPLAY3;
+
+    MN_DrTextACentered("GAMEPLAY", 10, cr[CR_YELLOW]);
+
+    // Default player class
+    M_snprintf(str, sizeof(str), "%s", DefClassName[gp_default_class]);
+    MN_DrTextA(str, M_ItemRightAlign(str), 20,
+               M_Item_Glow(0, gp_default_class == 0 ? GLOW_GREEN :
+                              gp_default_class == 1 ? GLOW_BLUE : GLOW_RED));
+
+    // Default skill level
+    M_snprintf(str, sizeof(str), "%s", DefSkillName[gp_default_skill]);
+    MN_DrTextA(str, M_ItemRightAlign(str), 30,
+               DefSkillColor(gp_default_skill));
+
+    // Flip levels horizontally
+    sprintf(str, gp_flip_levels ? "ON" : "OFF");
+    MN_DrTextA(str, M_ItemRightAlign(str), 40,
+               M_Item_Glow(2, gp_flip_levels ? GLOW_GREEN : GLOW_DARKRED));
+
+    // On death action
+    sprintf(str, gp_death_use_action == 1 ? "LAST SAVE" :
+                 gp_death_use_action == 2 ? "NOTHING" : "DEFAULT");
+    MN_DrTextA(str, M_ItemRightAlign(str), 50,
+               M_Item_Glow(3, gp_death_use_action ? GLOW_GREEN : GLOW_DARKRED));
+
+    MN_DrTextACentered("DEMOS", 60, cr[CR_YELLOW]);
+
+    // Show Demo timer
+    sprintf(str, demo_timer == 1 ? "PLAYBACK" : 
+                 demo_timer == 2 ? "RECORDING" : 
+                 demo_timer == 3 ? "ALWAYS" : "OFF");
+    MN_DrTextA(str, M_ItemRightAlign(str), 70,
+               M_Item_Glow(5, demo_timer ? GLOW_GREEN : GLOW_DARKRED));
+
+    // Timer direction
+    sprintf(str, demo_timerdir ? "BACKWARD" : "FORWARD");
+    MN_DrTextA(str, M_ItemRightAlign(str), 80,
+               M_Item_Glow(6, demo_timer ? GLOW_GREEN : GLOW_DARKRED));
+
+    // Show progress bar
+    sprintf(str, demo_bar ? "ON" : "OFF");
+    MN_DrTextA(str, M_ItemRightAlign(str), 90,
+               M_Item_Glow(7, demo_bar ? GLOW_GREEN : GLOW_DARKRED));
+
+    // Play internal demos
+    sprintf(str, demo_internal ? "ON" : "OFF");
+    MN_DrTextA(str, M_ItemRightAlign(str), 100,
+               M_Item_Glow(8, demo_internal ? GLOW_DARKRED : GLOW_GREEN));
+
+    MN_DrTextA("FIRST PAGE", ID_MENU_LEFTOFFSET, 140,
+               M_Item_Glow(12, GLOW_DARKGRAY));
+
+    // Footer
+    sprintf(str, "PAGE 3/3");
+    MN_DrTextA(str, M_ItemRightAlign(str), 140, M_Item_Glow(12, GLOW_DARKGRAY));
 }
 
 static void M_ID_DefaultClass (int choice)
@@ -3151,49 +3234,6 @@ static void M_ID_ProgressBar (int choice)
 static void M_ID_InternalDemos (int choice)
 {
     demo_internal ^= 1;
-}
-
-// -----------------------------------------------------------------------------
-// Gameplay features 3
-// -----------------------------------------------------------------------------
-
-static MenuItem_t ID_Menu_Gameplay_3[] = {
-    { ITT_LRFUNC,  "CORPSES SLIDING FROM LEDGES", M_ID_Torque,         0, MENU_NONE         },
-    { ITT_LRFUNC,  "IMITATE PLAYER'S BREATHING",  M_ID_Breathing,      0, MENU_NONE         },
-    { ITT_EMPTY,   NULL,                          NULL,                0, MENU_NONE         },
-    { ITT_LRFUNC,  "DEFAULT PLAYER CLASS",        M_ID_DefaultClass,   0, MENU_NONE         },
-    { ITT_LRFUNC,  "DEFAULT SKILL LEVEL",         M_ID_DefaultSkill,   0, MENU_NONE         },
-    { ITT_LRFUNC,  "FLIP LEVELS HORIZONTALLY",    M_ID_FlipLevels,     0, MENU_NONE         },
-    { ITT_LRFUNC,  "ON DEATH ACTION",             M_ID_OnDeathAction,  0, MENU_NONE         },
-    { ITT_EMPTY,   NULL,                          NULL,                0, MENU_NONE         },
-    { ITT_LRFUNC,  "SHOW DEMO TIMER",             M_ID_DemoTimer,      0, MENU_NONE         },
-    { ITT_LRFUNC,  "TIMER DIRECTION",             M_ID_TimerDirection, 0, MENU_NONE         },
-    { ITT_LRFUNC,  "SHOW PROGRESS BAR",           M_ID_ProgressBar,    0, MENU_NONE         },
-    { ITT_LRFUNC,  "PLAY INTERNAL DEMOS",         M_ID_InternalDemos,  0, MENU_NONE         },
-    { ITT_EMPTY,   NULL,                          NULL,                0, MENU_NONE         },
-    { ITT_SETMENU, "", /* FIRST PAGE */           NULL,                0, MENU_ID_GAMEPLAY1 },
-};
-
-static Menu_t ID_Def_Gameplay_3 = {
-    ID_MENU_LEFTOFFSET, ID_MENU_TOPOFFSET,
-    M_Draw_ID_Gameplay_3,
-    14, ID_Menu_Gameplay_3,
-    0,
-    true, false, true,
-    MENU_ID_MAIN
-};
-
-static void M_Draw_ID_Gameplay_3 (void)
-{
-    char str[32];
-    Gameplay_Cur = (MenuType_t)MENU_ID_GAMEPLAY3;
-
-    MN_DrTextA("FIRST PAGE", ID_MENU_LEFTOFFSET, 150,
-               M_Item_Glow(13, GLOW_DARKGRAY));
-
-    // Footer
-    sprintf(str, "PAGE 3/3");
-    MN_DrTextA(str, M_ItemRightAlign(str), 150, M_Item_Glow(13, GLOW_DARKGRAY));
 }
 
 // -----------------------------------------------------------------------------

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -3022,12 +3022,11 @@ static void M_Draw_ID_Gameplay_2 (void)
                M_Item_Glow(1, st_weapon_widget ? GLOW_GREEN : GLOW_DARKRED));
 
     // Armor icon
-    /*
-    sprintf(str, st_weapon_widget == 1 ? "SOLID" :
-                 st_weapon_widget == 2 ? "TRANSLUCENT" : "OFF");
+    sprintf(str, st_armor_icon ? "CLASS-BASED" : "GENERIC");
     MN_DrTextA(str, M_ItemRightAlign(str), 40,
-               M_Item_Glow(2, st_weapon_widget ? GLOW_GREEN : GLOW_DARKRED));
-    */
+               M_Item_Glow(2, !st_armor_icon ? GLOW_DARKRED :
+                               gp_default_class == 0 ? GLOW_GREEN :
+                               gp_default_class == 1 ? GLOW_BLUE : GLOW_RED));
 
     MN_DrTextACentered("AUDIBLE", 50, cr[CR_YELLOW]);
 
@@ -3078,7 +3077,7 @@ static void M_ID_WeaponWidget (int choice)
 
 static void M_ID_ArmorIcon (int choice)
 {
-    // phys_torque ^= 1;
+    st_armor_icon ^= 1;
 }
 
 static void M_ID_ZAxisSfx (int choice)
@@ -3325,6 +3324,7 @@ static void M_ID_ApplyResetHook (void)
     // Status bar
     st_colored_stbar = 0;
     st_weapon_widget = 0;
+    st_armor_icon = 0;
 
     // Physical
     phys_torque = 0;

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -558,7 +558,6 @@ static void M_ID_WeaponWidget (int choice);
 static void M_ID_ArmorIcon (int choice);
 static void M_ID_ZAxisSfx (int choice);
 static void M_ID_Torque (int choice);
-static void M_ID_WeaponAlignment (int choice);
 static void M_ID_Breathing (int choice);
 
 static void M_Draw_ID_Gameplay_3 (void);
@@ -2986,8 +2985,8 @@ static MenuItem_t ID_Menu_Gameplay_2[] = {
     { ITT_LRFUNC,  "SFX ATTENUATION AXISES",      M_ID_ZAxisSfx,        0, MENU_NONE         },
     { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
     { ITT_LRFUNC,  "CORPSES SLIDING FROM LEDGES", M_ID_Torque,          0, MENU_NONE         },
-    { ITT_LRFUNC,  "WEAPON ATTACK ALIGNMENT",     M_ID_WeaponAlignment, 0, MENU_NONE         },
     { ITT_LRFUNC,  "IMITATE PLAYER'S BREATHING",  M_ID_Breathing,       0, MENU_NONE         },
+    { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
     { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
     { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
     { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
@@ -3040,17 +3039,10 @@ static void M_Draw_ID_Gameplay_2 (void)
     MN_DrTextA(str, M_ItemRightAlign(str), 80,
                M_Item_Glow(6, phys_torque ? GLOW_GREEN : GLOW_DARKRED));
 
-    // Weapon attack alignment
-    /*
-    sprintf(str, phys_torque ? "ON" : "OFF");
-    MN_DrTextA(str, M_ItemRightAlign(str), 90,
-               M_Item_Glow(7, phys_torque ? GLOW_GREEN : GLOW_DARKRED));
-    */
-
     // Imitate player's breathing
     sprintf(str, phys_breathing ? "ON" : "OFF");
-    MN_DrTextA(str, M_ItemRightAlign(str), 100,
-               M_Item_Glow(8, phys_breathing ? GLOW_GREEN : GLOW_DARKRED));
+    MN_DrTextA(str, M_ItemRightAlign(str), 90,
+               M_Item_Glow(7, phys_breathing ? GLOW_GREEN : GLOW_DARKRED));
 
     MN_DrTextA("LAST PAGE", ID_MENU_LEFTOFFSET, 140,
                M_Item_Glow(12, GLOW_DARKGRAY));
@@ -3083,11 +3075,6 @@ static void M_ID_ZAxisSfx (int choice)
 static void M_ID_Torque (int choice)
 {
     phys_torque ^= 1;
-}
-
-static void M_ID_WeaponAlignment (int choice)
-{
-    // phys_torque ^= 1;
 }
 
 static void M_ID_Breathing (int choice)

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -3031,12 +3031,9 @@ static void M_Draw_ID_Gameplay_2 (void)
     MN_DrTextACentered("AUDIBLE", 50, cr[CR_YELLOW]);
 
     // Sfx Attenuation Axises
-    /*
-    sprintf(str, st_weapon_widget == 1 ? "SOLID" :
-                 st_weapon_widget == 2 ? "TRANSLUCENT" : "OFF");
+    sprintf(str, aud_z_axis_sfx ? "X/Y/Z" : "X/Y");
     MN_DrTextA(str, M_ItemRightAlign(str), 60,
-               M_Item_Glow(4, st_weapon_widget ? GLOW_GREEN : GLOW_DARKRED));
-    */
+               M_Item_Glow(4, aud_z_axis_sfx ? GLOW_GREEN : GLOW_DARKRED));
 
     MN_DrTextACentered("PHYSICAL", 70, cr[CR_YELLOW]);
 
@@ -3082,7 +3079,7 @@ static void M_ID_ArmorIcon (int choice)
 
 static void M_ID_ZAxisSfx (int choice)
 {
-    // phys_torque ^= 1;
+    aud_z_axis_sfx ^= 1;
 }
 
 static void M_ID_Torque (int choice)
@@ -3325,6 +3322,9 @@ static void M_ID_ApplyResetHook (void)
     st_colored_stbar = 0;
     st_weapon_widget = 0;
     st_armor_icon = 0;
+
+    // Audible
+    aud_z_axis_sfx = 0;
 
     // Physical
     phys_torque = 0;

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -3022,11 +3022,9 @@ static void M_Draw_ID_Gameplay_2 (void)
                M_Item_Glow(1, st_weapon_widget ? GLOW_GREEN : GLOW_DARKRED));
 
     // Armor icon
-    sprintf(str, st_armor_icon ? "CLASS-BASED" : "GENERIC");
+    sprintf(str, st_armor_icon ? "GENERIC" : "CLASS-BASED");
     MN_DrTextA(str, M_ItemRightAlign(str), 40,
-               M_Item_Glow(2, !st_armor_icon ? GLOW_DARKRED :
-                               gp_default_class == 0 ? GLOW_GREEN :
-                               gp_default_class == 1 ? GLOW_BLUE : GLOW_RED));
+               M_Item_Glow(2, st_armor_icon ? GLOW_GREEN : GLOW_DARKRED));
 
     MN_DrTextACentered("AUDIBLE", 50, cr[CR_YELLOW]);
 

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -89,6 +89,7 @@ typedef enum
     MENU_ID_WIDGETS,
     MENU_ID_GAMEPLAY1,
     MENU_ID_GAMEPLAY2,
+    MENU_ID_GAMEPLAY3,
     MENU_NONE
 } MenuType_t;
 
@@ -565,6 +566,8 @@ static void M_ID_TimerDirection (int choice);
 static void M_ID_ProgressBar (int choice);
 static void M_ID_InternalDemos (int choice);
 
+static void M_Draw_ID_Gameplay_3 (void);
+
 static void M_ID_SettingReset (int choice);
 static void M_ID_ApplyReset (void);
 
@@ -606,6 +609,7 @@ static Menu_t ID_Def_Keybinds_7;
 static Menu_t ID_Def_Keybinds_8;
 static Menu_t ID_Def_Gameplay_1;
 static Menu_t ID_Def_Gameplay_2;
+static Menu_t ID_Def_Gameplay_3;
 
 // Remember last keybindings page.
 static int Keybinds_Cur;
@@ -656,8 +660,9 @@ static void M_ScrollPages (boolean direction)
     else if (CurrentMenu == &ID_Def_Keybinds_8) SetMenu(direction ? MENU_ID_KBDBINDS1 : MENU_ID_KBDBINDS7);
 
     // Gameplay features:
-    else if (CurrentMenu == &ID_Def_Gameplay_1) SetMenu(MENU_ID_GAMEPLAY2);
-    else if (CurrentMenu == &ID_Def_Gameplay_2) SetMenu(MENU_ID_GAMEPLAY1);
+    else if (CurrentMenu == &ID_Def_Gameplay_1) SetMenu(direction ? MENU_ID_GAMEPLAY2 : MENU_ID_GAMEPLAY3);
+    else if (CurrentMenu == &ID_Def_Gameplay_2) SetMenu(direction ? MENU_ID_GAMEPLAY3 : MENU_ID_GAMEPLAY1);
+    else if (CurrentMenu == &ID_Def_Gameplay_3) SetMenu(direction ? MENU_ID_GAMEPLAY1 : MENU_ID_GAMEPLAY2);
 
     // Play sound.
     S_StartSound(NULL, SFX_DOOR_LIGHT_CLOSE);
@@ -2835,9 +2840,9 @@ static MenuItem_t ID_Menu_Gameplay_1[] = {
     { ITT_LRFUNC,  "INDICATION",                  M_ID_CrosshairColor,  0, MENU_NONE         },
     { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
     { ITT_LRFUNC,  "COLORED ELEMENTS",            M_ID_ColoredSBar,     0, MENU_NONE         },
-    { ITT_LRFUNC,  "4TH WEAPON WIDGET",            M_ID_WeaponWidget,    0, MENU_NONE         },
+    { ITT_LRFUNC,  "4TH WEAPON WIDGET",           M_ID_WeaponWidget,    0, MENU_NONE         },
     { ITT_EMPTY,   NULL,                          NULL,                 0, MENU_NONE         },
-    { ITT_SETMENU, "", /*NEXT PAGE >*/            NULL,                 0, MENU_ID_GAMEPLAY2 },
+    { ITT_SETMENU, "", /* NEXT PAGE */            NULL,                 0, MENU_ID_GAMEPLAY2 },
 };
 
 static Menu_t ID_Def_Gameplay_1 = {
@@ -2925,7 +2930,7 @@ static void M_Draw_ID_Gameplay_1 (void)
                M_Item_Glow(13, GLOW_DARKGRAY));
 
     // Footer
-    sprintf(str, "PAGE 1/2");
+    sprintf(str, "PAGE 1/3");
     MN_DrTextA(str, M_ItemRightAlign(str), 150, M_Item_Glow(13, GLOW_DARKGRAY));
 }
 
@@ -3008,7 +3013,7 @@ static MenuItem_t ID_Menu_Gameplay_2[] = {
     { ITT_LRFUNC,  "SHOW PROGRESS BAR",           M_ID_ProgressBar,    0, MENU_NONE         },
     { ITT_LRFUNC,  "PLAY INTERNAL DEMOS",         M_ID_InternalDemos,  0, MENU_NONE         },
     { ITT_EMPTY,   NULL,                          NULL,                0, MENU_NONE         },
-    { ITT_SETMENU, "", /*PREVIOUS PAGE >*/        NULL,                0, MENU_ID_GAMEPLAY1 },
+    { ITT_SETMENU, "", /* LAST PAGE */            NULL,                0, MENU_ID_GAMEPLAY3 },
 };
 
 static Menu_t ID_Def_Gameplay_2 = {
@@ -3085,11 +3090,11 @@ static void M_Draw_ID_Gameplay_2 (void)
     MN_DrTextA(str, M_ItemRightAlign(str), 130,
                M_Item_Glow(11, demo_internal ? GLOW_DARKRED : GLOW_GREEN));
 
-    MN_DrTextA("PREVIOUS PAGE", ID_MENU_LEFTOFFSET, 150,
+    MN_DrTextA("LAST PAGE", ID_MENU_LEFTOFFSET, 150,
                M_Item_Glow(13, GLOW_DARKGRAY));
 
     // Footer
-    sprintf(str, "PAGE 2/2");
+    sprintf(str, "PAGE 2/3");
     MN_DrTextA(str, M_ItemRightAlign(str), 150, M_Item_Glow(13, GLOW_DARKGRAY));
 }
 
@@ -3146,6 +3151,49 @@ static void M_ID_ProgressBar (int choice)
 static void M_ID_InternalDemos (int choice)
 {
     demo_internal ^= 1;
+}
+
+// -----------------------------------------------------------------------------
+// Gameplay features 3
+// -----------------------------------------------------------------------------
+
+static MenuItem_t ID_Menu_Gameplay_3[] = {
+    { ITT_LRFUNC,  "CORPSES SLIDING FROM LEDGES", M_ID_Torque,         0, MENU_NONE         },
+    { ITT_LRFUNC,  "IMITATE PLAYER'S BREATHING",  M_ID_Breathing,      0, MENU_NONE         },
+    { ITT_EMPTY,   NULL,                          NULL,                0, MENU_NONE         },
+    { ITT_LRFUNC,  "DEFAULT PLAYER CLASS",        M_ID_DefaultClass,   0, MENU_NONE         },
+    { ITT_LRFUNC,  "DEFAULT SKILL LEVEL",         M_ID_DefaultSkill,   0, MENU_NONE         },
+    { ITT_LRFUNC,  "FLIP LEVELS HORIZONTALLY",    M_ID_FlipLevels,     0, MENU_NONE         },
+    { ITT_LRFUNC,  "ON DEATH ACTION",             M_ID_OnDeathAction,  0, MENU_NONE         },
+    { ITT_EMPTY,   NULL,                          NULL,                0, MENU_NONE         },
+    { ITT_LRFUNC,  "SHOW DEMO TIMER",             M_ID_DemoTimer,      0, MENU_NONE         },
+    { ITT_LRFUNC,  "TIMER DIRECTION",             M_ID_TimerDirection, 0, MENU_NONE         },
+    { ITT_LRFUNC,  "SHOW PROGRESS BAR",           M_ID_ProgressBar,    0, MENU_NONE         },
+    { ITT_LRFUNC,  "PLAY INTERNAL DEMOS",         M_ID_InternalDemos,  0, MENU_NONE         },
+    { ITT_EMPTY,   NULL,                          NULL,                0, MENU_NONE         },
+    { ITT_SETMENU, "", /* FIRST PAGE */           NULL,                0, MENU_ID_GAMEPLAY1 },
+};
+
+static Menu_t ID_Def_Gameplay_3 = {
+    ID_MENU_LEFTOFFSET, ID_MENU_TOPOFFSET,
+    M_Draw_ID_Gameplay_3,
+    14, ID_Menu_Gameplay_3,
+    0,
+    true, false, true,
+    MENU_ID_MAIN
+};
+
+static void M_Draw_ID_Gameplay_3 (void)
+{
+    char str[32];
+    Gameplay_Cur = (MenuType_t)MENU_ID_GAMEPLAY3;
+
+    MN_DrTextA("FIRST PAGE", ID_MENU_LEFTOFFSET, 150,
+               M_Item_Glow(13, GLOW_DARKGRAY));
+
+    // Footer
+    sprintf(str, "PAGE 3/3");
+    MN_DrTextA(str, M_ItemRightAlign(str), 150, M_Item_Glow(13, GLOW_DARKGRAY));
 }
 
 // -----------------------------------------------------------------------------
@@ -3327,6 +3375,7 @@ static Menu_t *Menus[] = {
     &ID_Def_Widgets,
     &ID_Def_Gameplay_1,
     &ID_Def_Gameplay_2,
+    &ID_Def_Gameplay_3,
 };
 
 //---------------------------------------------------------------------------

--- a/src/hexen/p_pspr.c
+++ b/src/hexen/p_pspr.c
@@ -2490,44 +2490,4 @@ void P_MovePsprites(player_t * player)
     }
     player->psprites[ps_flash].sx = player->psprites[ps_weapon].sx;
     player->psprites[ps_flash].sy = player->psprites[ps_weapon].sy;
-
-    // [crispy] apply bobbing (or centering) to the player's weapon sprite
-    psp = &player->psprites[0];
-    psp->sx2 = psp->sx;
-    psp->sy2 = psp->sy;
-    // [JN] TODO
-    /*
-    if (psp->state && (phys_weapon_alignment || vid_uncapped_fps))
-    {
-        // [crispy] don't align swiping weapons
-        const boolean swiping_weapon = player->class == PCLASS_FIGHTER ||
-                                       (player->class == PCLASS_CLERIC &&
-                                        player->readyweapon == WP_FIRST);
-
-        // [crispy] don't center vertically during lowering and raising states
-        if (psp->state->action == A_Lower || psp->state->action == A_Raise)
-        {
-        }
-        else
-        // [crispy] not attacking means idle
-        if (!player->attackdown ||
-            (phys_weapon_alignment == 2 && !swiping_weapon))
-        {
-            angle_t angle = (128 * leveltime) & FINEMASK;
-            psp->sx2 = FRACUNIT + FixedMul(player->bob2, finecosine[angle]);
-            angle &= FINEANGLES / 2 - 1;
-            psp->sy2 = WEAPONTOP + FixedMul(player->bob2, finesine[angle]);
-        }
-        else
-        // [crispy] center the weapon sprite horizontally and push up vertically
-        if (phys_weapon_alignment == 2 && !swiping_weapon)
-        {
-            psp->sx2 = FRACUNIT;
-            psp->sy2 = WEAPONTOP;
-        }
-    }
-    */
-
-    player->psprites[ps_flash].sx2 = psp->sx2;
-    player->psprites[ps_flash].sy2 = psp->sy2;
 }

--- a/src/hexen/r_things.c
+++ b/src/hexen/r_things.c
@@ -821,7 +821,7 @@ void R_DrawPSprite(pspdef_t * psp)
 //
 // calculate edges of the shape
 //
-    tx = psp->sx2 - 160 * FRACUNIT;
+    tx = psp->sx - 160 * FRACUNIT;
 
     // [crispy] fix sprite offsets for mirrored sprites
     tx -= flip ? 2 * tx - spriteoffset[lump] + spritewidth[lump] : spriteoffset[lump];
@@ -852,7 +852,7 @@ void R_DrawPSprite(pspdef_t * psp)
     vis->psprite = true;
     vis->floorclip = 0;
     vis->texturemid = (BASEYCENTER << FRACBITS) /* + FRACUNIT / 2 */
-        - (psp->sy2 - spritetopoffset[lump]);
+        - (psp->sy - spritetopoffset[lump]);
     if (viewheight == SCREENHEIGHT)
     {
         vis->texturemid -= PSpriteSY[viewplayer->class]

--- a/src/hexen/sb_bar.c
+++ b/src/hexen/sb_bar.c
@@ -1738,6 +1738,24 @@ static const char *PiecesGfx[][3] = {
     {"WMS1A0", "WMS2A0", "WMS3A0"},
 };
 
+static const int ClassArmorX[3] = {
+    96, // Fighter
+    94, // Cleric
+    94, // Mage
+};
+
+static const int ClassArmorY[3] = {
+    214, // Fighter
+    212, // Cleric
+    208, // Mage
+};
+
+static const char *ClassArmorIcon[3] = {
+    "ARM1A0", // Mesh armor
+    "ARM2A0", // Falcon Shield
+    "ARM4A0", // Amulet of Warding
+};
+
 // -----------------------------------------------------------------------------
 // DrawFullScreenStuff
 // [JN] Upgraded to draw extra elements.
@@ -1768,8 +1786,19 @@ static void DrawFullScreenStuff(void)
             dp_translation = SB_NumberColor(hudcolor_armor);
             DrBNumber(FixedDiv(currentArmor, 5 * FRACUNIT) >> FRACBITS, 41 - wide_x, 175);
             dp_translation = NULL;
-            // Draw generic armor icon.
-            V_DrawShadowedPatch(81 - wide_x, 176, (patch_t*)id_armor_icon);
+            if (st_armor_icon)
+            {
+                const int class = PlayerClass[displayplayer];
+                
+                // Draw class-based icon.
+                V_DrawShadowedPatch(ClassArmorX[class] - wide_x, ClassArmorY[class],
+                                    W_CacheLumpName(ClassArmorIcon[class], PU_CACHE));
+            }
+            else
+            {
+                // Draw generic armor icon.
+                V_DrawShadowedPatch(81 - wide_x, 176, (patch_t*)id_armor_icon);
+            }
         }
 
         // Frags.

--- a/src/hexen/sb_bar.c
+++ b/src/hexen/sb_bar.c
@@ -1689,6 +1689,25 @@ static void DrawWeaponPieces(void)
     }
 }
 
+// [JN] Class-based icon variables.
+static const int ClassArmorX[3] = {
+    96, // Fighter
+    94, // Cleric
+    94, // Mage
+};
+
+static const int ClassArmorY[3] = {
+    214, // Fighter
+    212, // Cleric
+    208, // Mage
+};
+
+static const char *ClassArmorIcon[3] = {
+    "ARM1A0", // Mesh armor
+    "ARM2A0", // Falcon Shield
+    "ARM4A0", // Amulet of Warding
+};
+
 // [JN] Generic armor icon.
 static const byte id_armor_icon[] =
 {
@@ -1738,24 +1757,6 @@ static const char *PiecesGfx[][3] = {
     {"WMS1A0", "WMS2A0", "WMS3A0"},
 };
 
-static const int ClassArmorX[3] = {
-    96, // Fighter
-    94, // Cleric
-    94, // Mage
-};
-
-static const int ClassArmorY[3] = {
-    214, // Fighter
-    212, // Cleric
-    208, // Mage
-};
-
-static const char *ClassArmorIcon[3] = {
-    "ARM1A0", // Mesh armor
-    "ARM2A0", // Falcon Shield
-    "ARM4A0", // Amulet of Warding
-};
-
 // -----------------------------------------------------------------------------
 // DrawFullScreenStuff
 // [JN] Upgraded to draw extra elements.
@@ -1764,6 +1765,7 @@ static const char *ClassArmorIcon[3] = {
 static void DrawFullScreenStuff(void)
 {
     const int wide_x = dp_screen_size == 12 ? WIDESCREENDELTA : 0;
+    const int class = PlayerClass[displayplayer];
     int i;
 
     // Health.
@@ -1788,16 +1790,14 @@ static void DrawFullScreenStuff(void)
             dp_translation = NULL;
             if (st_armor_icon)
             {
-                const int class = PlayerClass[displayplayer];
-                
-                // Draw class-based icon.
-                V_DrawShadowedPatch(ClassArmorX[class] - wide_x, ClassArmorY[class],
-                                    W_CacheLumpName(ClassArmorIcon[class], PU_CACHE));
+                // Draw generic armor icon.
+                V_DrawShadowedPatch(81 - wide_x, 176, (patch_t*)id_armor_icon);
             }
             else
             {
-                // Draw generic armor icon.
-                V_DrawShadowedPatch(81 - wide_x, 176, (patch_t*)id_armor_icon);
+                // Draw class-based icon.
+                V_DrawShadowedPatch(ClassArmorX[class] - wide_x, ClassArmorY[class],
+                                    W_CacheLumpName(ClassArmorIcon[class], PU_CACHE));
             }
         }
 
@@ -1899,7 +1899,6 @@ static void DrawFullScreenStuff(void)
     // [JN] Assembled weapon widget.
     if (st_weapon_widget)
     {
-        const int class = PlayerClass[displayplayer];
         patch_t *patch1 = W_CacheLumpNum(W_CheckNumForName(PiecesGfx[class][0]), PU_CACHE);
         patch_t *patch2 = W_CacheLumpNum(W_CheckNumForName(PiecesGfx[class][1]), PU_CACHE);
         patch_t *patch3 = W_CacheLumpNum(W_CheckNumForName(PiecesGfx[class][2]), PU_CACHE);

--- a/src/hexen/sv_save.c
+++ b/src/hexen/sv_save.c
@@ -314,10 +314,6 @@ static void StreamIn_pspdef_t(pspdef_t *str)
     // fixed_t sx, sy;
     str->sx = SV_ReadLong();
     str->sy = SV_ReadLong();
-
-    // [crispy] variable weapon sprite bob
-    str->sx2 = str->sx;
-    str->sy2 = str->sy;
 }
 
 static void StreamOut_pspdef_t(pspdef_t *str)

--- a/src/id_vars.c
+++ b/src/id_vars.c
@@ -131,6 +131,7 @@ int st_ammo_widget = 0;
 int st_ammo_widget_translucent = 0;
 int st_ammo_widget_colors = 0;
 int st_weapon_widget = 0;
+int st_armor_icon = 0;
 
 // Audible
 int aud_z_axis_sfx = 0;
@@ -307,6 +308,7 @@ void ID_BindVariables (GameMission_t mission)
     if (mission == hexen)
     {
         M_BindIntVariable("st_weapon_widget",           &st_weapon_widget);
+        M_BindIntVariable("st_armor_icon",              &st_armor_icon);
     }        
     
     // Audible

--- a/src/id_vars.c
+++ b/src/id_vars.c
@@ -312,10 +312,7 @@ void ID_BindVariables (GameMission_t mission)
     }        
     
     // Audible
-    if (mission == doom || mission == heretic)
-    {
-        M_BindIntVariable("aud_z_axis_sfx",             &aud_z_axis_sfx);
-    }
+    M_BindIntVariable("aud_z_axis_sfx",                 &aud_z_axis_sfx);
     if (mission == doom)
     {
         M_BindIntVariable("aud_full_sounds",            &aud_full_sounds);

--- a/src/id_vars.c
+++ b/src/id_vars.c
@@ -327,7 +327,10 @@ void ID_BindVariables (GameMission_t mission)
         M_BindIntVariable("phys_toss_drop",             &phys_toss_drop);
         M_BindIntVariable("phys_floating_powerups",     &phys_floating_powerups);
     }
-    M_BindIntVariable("phys_weapon_alignment",          &phys_weapon_alignment);
+    if (mission == doom || mission == heretic)
+    {
+        M_BindIntVariable("phys_weapon_alignment",      &phys_weapon_alignment);
+    }
     M_BindIntVariable("phys_breathing",                 &phys_breathing);
     
     // Gameplay

--- a/src/id_vars.h
+++ b/src/id_vars.h
@@ -109,6 +109,7 @@ extern int st_ammo_widget;  // Heretic only
 extern int st_ammo_widget_translucent;  // Heretic only
 extern int st_ammo_widget_colors;  // Heretic only
 extern int st_weapon_widget;  // Hexen only
+extern int st_armor_icon;  // Hexen only
 
 extern int aud_z_axis_sfx;
 extern int aud_full_sounds;

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -528,6 +528,7 @@ static default_t	doom_defaults_list[] =
     CONFIG_VARIABLE_INT(st_ammo_widget_translucent),
     CONFIG_VARIABLE_INT(st_ammo_widget_colors),
     CONFIG_VARIABLE_INT(st_weapon_widget),
+    CONFIG_VARIABLE_INT(st_armor_icon),
 
     // Audible
     CONFIG_VARIABLE_INT(aud_z_axis_sfx),


### PR DESCRIPTION
* Class-based armor: now default. Original port settings is matching up vanilla executable, and generic icon is not really vanilla. In other words, this is a Right Thing to do.
* SFX attenuation axises: not that epic as in Doom and Heretic, it works only for monsters and thing-type map objects, i.e. not doors, sectors, platforms, etc.. Hexen handles sectors slightly differently, but even attenuation for thing-type only seems to be okay.

Weapon attack alignment removed entirely, it's working only with half of weapons. 🙁 That's because of Hexen's "extra" coords shifting for some frames, i.e. weapon state can be same to prevent extra sprite graphics, but may have different offset. 