### PR TITLE
Heretic and Hexen: upgrade spy mode

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1991,7 +1991,7 @@ void D_DoomMain (void)
     D_ConnectNetGame();
 
     // get skill / episode / map from parms
-    // [JN] Use choosen default skill level.
+    // [JN] Use chosen default skill level.
     startskill = gp_default_skill;
     startepisode = 1;
     startmap = 1;

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -831,7 +831,7 @@ void G_DoLoadLevel (void)
 
     P_SetupLevel (gameepisode, gamemap);    
     // view the guy you are playing
-    // [JN] Do not reset choosen player view while multiplayer demo playback.
+    // [JN] Do not reset chosen player view while multiplayer demo playback.
     if (!netgame && !demoplayback)
     {
         displayplayer = consoleplayer;

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -830,7 +830,12 @@ void G_DoLoadLevel (void)
     }
 
     P_SetupLevel (gameepisode, gamemap);    
-    displayplayer = consoleplayer;		// view the guy you are playing    
+    // view the guy you are playing
+    // [JN] But do not reset choosen player view while demo playback.
+    if (!demoplayback)
+    {
+        displayplayer = consoleplayer;
+    } 
     gameaction = ga_nothing; 
     Z_CheckHeap ();
     
@@ -959,6 +964,8 @@ boolean G_Responder (event_t* ev)
 	    if (displayplayer == MAXPLAYERS) 
 		displayplayer = 0; 
 	} while (!playeringame[displayplayer] && displayplayer != consoleplayer); 
+    // [JN] Refresh status bar.
+    st_fullupdate = true;
     // [JN] Update sound values for appropriate player.
 	S_UpdateSounds(players[displayplayer].mo);
 	// [JN] Re-init automap variables for correct player arrow angle.

--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -831,8 +831,8 @@ void G_DoLoadLevel (void)
 
     P_SetupLevel (gameepisode, gamemap);    
     // view the guy you are playing
-    // [JN] But do not reset choosen player view while demo playback.
-    if (!demoplayback)
+    // [JN] Do not reset choosen player view while multiplayer demo playback.
+    if (!netgame && !demoplayback)
     {
         displayplayer = consoleplayer;
     } 

--- a/src/heretic/am_map.h
+++ b/src/heretic/am_map.h
@@ -35,6 +35,7 @@ extern const char *LevelNames[];
 
 extern void AM_ClearMarks (void);
 extern void AM_Init (void);
+extern void AM_initVariables (void);
 extern void AM_LevelInit (boolean reinit);
 extern void AM_LevelNameDrawer (void);
 extern void AM_Start (void);

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -385,7 +385,7 @@ void D_DoomLoop(void)
                 S_MuteUnmuteSound (!window_focused);
             }
 
-            S_UpdateSounds(players[consoleplayer].mo);
+            S_UpdateSounds(players[displayplayer].mo);
             oldgametic = gametic;
         }
 

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -127,7 +127,7 @@ void D_ProcessEvents(void)
 
 static void DrawMessage (void)
 {
-    player_t *player = &players[consoleplayer];
+    player_t *player = &players[displayplayer];
     
     if (player->messageTics <= 0 || !player->message)
     {                           // No message

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1027,7 +1027,7 @@ void D_DoomMain(void)
     }
 #endif
 
-    // [JN] Use choosen default skill level.
+    // [JN] Use chosen default skill level.
     startskill = gp_default_skill;
 
     //!

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -960,7 +960,12 @@ void G_DoLoadLevel(void)
     }
 
     P_SetupLevel(gameepisode, gamemap, 0, gameskill);
-    displayplayer = consoleplayer;      // view the guy you are playing
+    // view the guy you are playing
+    // [JN] But do not reset choosen player view while demo playback.
+    if (!demoplayback)
+    {
+        displayplayer = consoleplayer;
+    }
     gameaction = ga_nothing;
     Z_CheckHeap();
 
@@ -1204,6 +1209,11 @@ boolean G_Responder(event_t * ev)
                && displayplayer != consoleplayer);
         // [JN] Refresh status bar.
         SB_ForceRedraw();
+        // [JN] Update sound values for appropriate player.
+        S_UpdateSounds(players[displayplayer].mo);
+        // [JN] Re-init automap variables for correct player arrow angle.
+        if (automapactive)
+        AM_initVariables();
         return (true);
     }
 

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -961,8 +961,8 @@ void G_DoLoadLevel(void)
 
     P_SetupLevel(gameepisode, gamemap, 0, gameskill);
     // view the guy you are playing
-    // [JN] But do not reset choosen player view while demo playback.
-    if (!demoplayback)
+    // [JN] Do not reset choosen player view while multiplayer demo playback.
+    if (!netgame && !demoplayback)
     {
         displayplayer = consoleplayer;
     }

--- a/src/heretic/g_game.c
+++ b/src/heretic/g_game.c
@@ -961,7 +961,7 @@ void G_DoLoadLevel(void)
 
     P_SetupLevel(gameepisode, gamemap, 0, gameskill);
     // view the guy you are playing
-    // [JN] Do not reset choosen player view while multiplayer demo playback.
+    // [JN] Do not reset chosen player view while multiplayer demo playback.
     if (!netgame && !demoplayback)
     {
         displayplayer = consoleplayer;
@@ -2216,7 +2216,7 @@ void G_DoLoadGame(void)
     gameskill = SV_ReadByte();
     gameepisode = SV_ReadByte();
     gamemap = SV_ReadByte();
-    // [JN] Read choosen by IDMUS music from saved game.
+    // [JN] Read chosen by IDMUS music from saved game.
     idmusnum = SV_ReadByte();
     // [JN] jff 3/18/98 account for unsigned byte
     if (idmusnum == 255)
@@ -3167,7 +3167,7 @@ void G_DoSaveGame(void)
     SV_WriteByte(gameskill);
     SV_WriteByte(gameepisode);
     SV_WriteByte(gamemap);
-    // [JN] Write choosen by IDMUS music into saved game.
+    // [JN] Write chosen by IDMUS music into saved game.
     SV_WriteByte(idmusnum);
     for (i = 0; i < MAXPLAYERS; i++)
     {

--- a/src/heretic/s_sound.c
+++ b/src/heretic/s_sound.c
@@ -64,7 +64,7 @@ void S_Start(void)
 {
     int i;
 
-    // [JN] If music was choosen by cheat code, play it.
+    // [JN] If music was chosen by cheat code, play it.
     if (idmusnum != -1)
     {
         S_StartSong(idmusnum, true);

--- a/src/hexen/am_map.h
+++ b/src/hexen/am_map.h
@@ -100,6 +100,7 @@ extern int markpointnum_max;
 
 extern void AM_ClearMarks (void);
 extern void AM_Init (void);
+extern void AM_initVariables (void);
 extern void AM_LevelInit (boolean reinit);
 extern void AM_LevelNameDrawer (void);
 extern void AM_Start (void);

--- a/src/hexen/d_net.c
+++ b/src/hexen/d_net.c
@@ -193,7 +193,7 @@ static void InitConnectData(net_connect_data_t *connect_data)
     }
     else
     {
-        // [JN] Use choosen default player class.
+        // [JN] Use chosen default player class.
         connect_data->player_class = gp_default_class;
     }
 

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -1157,6 +1157,8 @@ boolean G_Responder(event_t * ev)
             {
                 displayplayer = 0;
             }
+            // [JN] Re-set appropriate assembled weapon widget graphics.
+            SB_SetClassData();
         }
         while (!playeringame[displayplayer]
                && displayplayer != consoleplayer);
@@ -2747,6 +2749,9 @@ void G_DoPlayDemo(void)
     {
         netdemo = true;
     }
+
+    // [JN] Set appropriate assembled weapon widget graphics.
+    SB_SetClassData();
 
     // [crispy] demo progress bar
     G_DemoProgressBar(lumplength);

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -919,8 +919,8 @@ void G_DoLoadLevel(void)
     SN_StopAllSequences();
     P_SetupLevel(gameepisode, gamemap, 0, gameskill);
     // view the guy you are playing
-    // [JN] But do not reset choosen player view while demo playback.
-    if (!demoplayback)
+    // [JN] Do not reset choosen player view while multiplayer demo playback.
+    if (!netgame && !demoplayback)
     {
         displayplayer = consoleplayer;
     }

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -918,7 +918,12 @@ void G_DoLoadLevel(void)
 
     SN_StopAllSequences();
     P_SetupLevel(gameepisode, gamemap, 0, gameskill);
-    displayplayer = consoleplayer;      // view the guy you are playing   
+    // view the guy you are playing
+    // [JN] But do not reset choosen player view while demo playback.
+    if (!demoplayback)
+    {
+        displayplayer = consoleplayer;
+    }
     gameaction = ga_nothing;
     Z_CheckHeap();
 
@@ -1162,6 +1167,13 @@ boolean G_Responder(event_t * ev)
         }
         while (!playeringame[displayplayer]
                && displayplayer != consoleplayer);
+        // [JN] Refresh status bar.
+        SB_ForceRedraw();
+        // [JN] Update sound values for appropriate player.
+        S_UpdateSounds(players[displayplayer].mo);
+        // [JN] Re-init automap variables for correct player arrow angle.
+        if (automapactive)
+        AM_initVariables();
         return (true);
     }
 

--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -919,7 +919,7 @@ void G_DoLoadLevel(void)
     SN_StopAllSequences();
     P_SetupLevel(gameepisode, gamemap, 0, gameskill);
     // view the guy you are playing
-    // [JN] Do not reset choosen player view while multiplayer demo playback.
+    // [JN] Do not reset chosen player view while multiplayer demo playback.
     if (!netgame && !demoplayback)
     {
         displayplayer = consoleplayer;

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -1147,7 +1147,7 @@ static void DrawMessage(void)
 {
     player_t *player;
 
-    player = &players[consoleplayer];
+    player = &players[displayplayer];
     if (player->messageTics <= 0)
     {                           // No message
         return;

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -446,7 +446,7 @@ void D_DoomMain(void)
 
     I_AtExit(M_SaveDefaults, true); // [crispy] always save configuration at exit
 
-    // [JN] Use choosen default skill level.
+    // [JN] Use chosen default skill level.
     startskill = gp_default_skill;
 
     // Now that the savedir is loaded, make sure it exists

--- a/src/hexen/sb_bar.c
+++ b/src/hexen/sb_bar.c
@@ -424,7 +424,7 @@ void SB_SetClassData(void)
 {
     int class;
 
-    class = PlayerClass[consoleplayer]; // original player class (not pig)
+    class = PlayerClass[displayplayer]; // original player class (not pig)
     PatchWEAPONSLOT = W_CacheLumpNum(W_GetNumForName("wpslot0")
                                      + class, PU_STATIC);
     PatchWEAPONFULL = W_CacheLumpNum(W_GetNumForName("wpfull0")
@@ -444,7 +444,7 @@ void SB_SetClassData(void)
     else
     {
         PatchLIFEGEM = W_CacheLumpNum(W_GetNumForName("lifegem")
-                                      + maxplayers * class + consoleplayer,
+                                      + maxplayers * class + displayplayer,
                                       PU_STATIC);
     }
     SB_state = -1;
@@ -461,7 +461,7 @@ void SB_Ticker(void)
     int delta;
     int curHealth;
 
-    curHealth = players[consoleplayer].mo->health;
+    curHealth = players[displayplayer].mo->health;
     if (curHealth < 0)
     {
         curHealth = 0;
@@ -875,7 +875,7 @@ void SB_Drawer(void)
     {
         DrawSoundInfo();
     }
-    CPlayer = &players[consoleplayer];
+    CPlayer = &players[displayplayer];
     if (viewheight == SCREENHEIGHT
         && !(automapactive && !automap_overlay))
     {
@@ -1233,7 +1233,7 @@ void SB_PaletteFlash(boolean forceChange)
     }
     if (gamestate == GS_LEVEL)
     {
-        CPlayer = &players[consoleplayer];
+        CPlayer = &players[displayplayer];
         if (CPlayer->poisoncount)
         {
             palette = 0;
@@ -1677,15 +1677,15 @@ static void DrawWeaponPieces(void)
     V_DrawPatch(190, 162, PatchWEAPONSLOT);
     if (CPlayer->pieces & WPIECE1)
     {
-        V_DrawPatch(PieceX[PlayerClass[consoleplayer]][0], 162, PatchPIECE1);
+        V_DrawPatch(PieceX[PlayerClass[displayplayer]][0], 162, PatchPIECE1);
     }
     if (CPlayer->pieces & WPIECE2)
     {
-        V_DrawPatch(PieceX[PlayerClass[consoleplayer]][1], 162, PatchPIECE2);
+        V_DrawPatch(PieceX[PlayerClass[displayplayer]][1], 162, PatchPIECE2);
     }
     if (CPlayer->pieces & WPIECE3)
     {
-        V_DrawPatch(PieceX[PlayerClass[consoleplayer]][2], 162, PatchPIECE3);
+        V_DrawPatch(PieceX[PlayerClass[displayplayer]][2], 162, PatchPIECE3);
     }
 }
 


### PR DESCRIPTION
Initially was planned for Hexen only, but other games gets improvements as well:
* All games: chosen by `F12` player now kept between level changes while multiplayer demo playback. No need to change player over and over again on every level change (probably could be useful for Woof and Crispy, if @fabiangreffrath and @rfomin will be interested?)
* Heretic: better toggling, notably automap showing correct player arrow angle on overlay mode.
* Hexen: full implementation.
* Heretic and Hexen: messages now showing correctly for chosen by `F12` player.

TODO for later:
* Heretic showing incorrect player arrow color in multiplayer. Will fix after @kitchen-ace's improved secret sectors handling, so we don't have a possible diff issues.