### PR TITLE
Add `savegames_path`, `screenshots_path` config variables and `-shotdir` parameter

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -102,7 +102,6 @@ static boolean storedemo;  // Store demo, do not accept any inputs
 static int   demosequence;
 static int   pagetic;
 static const char *pagename;
-static char *SavePathConfig;  // [JN] "savegames_path" config file variable.
 
 // If true, the main game loop has started.
 boolean main_loop_started = false;
@@ -474,39 +473,6 @@ void D_BindVariables(void)
 
 	// [JN] Bind ID-specific config variables.
 	ID_BindVariables(doom);
-}
-
-// -----------------------------------------------------------------------------
-// D_SetDefaultSavePath
-// [JN] Set the default directory where savegames are saved.
-// -----------------------------------------------------------------------------
-
-static void D_SetDefaultSavePath (void)
-{
-    // Gather default "savegames" folder location.
-    savegamedir = M_GetSaveGameDir(D_SaveGameIWADName(gamemission, gamevariant));
-
-    if (!strcmp(savegamedir, ""))
-    {
-        if (SavePathConfig == NULL || !strcmp(SavePathConfig, ""))
-        {
-            // Config file variable not existing or emptry,
-            // so use generated path from above.
-            savegamedir = M_StringDuplicate("");
-        }
-        else
-        {
-            // Variable existing, use it's path.
-            savegamedir = M_StringDuplicate(SavePathConfig);
-        }
-    }
-
-    // Overwrite config file variable only if following command line
-    // parameters are not present:
-    if (!M_ParmExists("-savedir") && !M_ParmExists("-cdrom"))
-    {
-        SavePathConfig = savegamedir;
-    }
 }
 
 //
@@ -1961,7 +1927,7 @@ void D_DoomMain (void)
     D_SetGameDescription();
 
     // [JN] Set the default directory where savegames are saved.
-    D_SetDefaultSavePath();
+    savegamedir = M_GetSaveGameDir(D_SaveGameIWADName(gamemission, gamevariant));
 
     // [JN] Set the default directory where screenshots are saved.
     M_SetScreenshotDir();

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -102,7 +102,7 @@ static boolean storedemo;  // Store demo, do not accept any inputs
 static int   demosequence;
 static int   pagetic;
 static const char *pagename;
-static char *SavePathConfig;  // [JN] "savedir" config file variable.
+static char *SavePathConfig;  // [JN] "savegames_path" config file variable.
 
 // If true, the main game loop has started.
 boolean main_loop_started = false;

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -1659,9 +1659,6 @@ void D_DoomMain (void)
     D_BindVariables();
     M_LoadDefaults();
 
-    // [JN] Set screeenshot files dir.
-    M_SetScreenshotDir();
-
     // [JN] Disk icon can be enabled for Doom.
     diskicon_enabled = true;
 
@@ -1965,6 +1962,9 @@ void D_DoomMain (void)
 
     // [JN] Set the default directory where savegames are saved.
     D_SetDefaultSavePath();
+
+    // [JN] Set the default directory where screenshots are saved.
+    M_SetScreenshotDir();
 
     // Check for -file in shareware
     if (modifiedgame && (gamevariant != freedoom))

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -457,6 +457,9 @@ void D_BindVariables(void)
     M_BindIntVariable("key_message_refresh",    &key_message_refresh);
     M_BindIntVariable("sfx_volume",             &sfxVolume);
     M_BindIntVariable("music_volume",           &musicVolume);
+    
+    M_BindStringVariable("savegames_path",      &SavePathConfig);
+    M_BindStringVariable("screenshots_path",    &ShotPathConfig);
 
     // Multiplayer chat macros
 

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -458,9 +458,6 @@ void D_BindVariables(void)
     M_BindIntVariable("sfx_volume",             &sfxVolume);
     M_BindIntVariable("music_volume",           &musicVolume);
 
-    M_BindStringVariable("savegames_path",      &SavePathConfig);
-    M_BindStringVariable("screenshots_path",    &ShotPathConfig);
-
     // Multiplayer chat macros
 
     for (i=0; i<10; ++i)

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -459,7 +459,8 @@ void D_BindVariables(void)
     M_BindIntVariable("sfx_volume",             &sfxVolume);
     M_BindIntVariable("music_volume",           &musicVolume);
 
-    M_BindStringVariable("savedir", &SavePathConfig);
+    M_BindStringVariable("savegames_path",      &SavePathConfig);
+    M_BindStringVariable("screenshots_path",    &ShotPathConfig);
 
     // Multiplayer chat macros
 

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -811,7 +811,8 @@ void D_BindVariables(void)
     M_BindIntVariable("music_volume",           &snd_MusicVolume);
     //M_BindIntVariable("graphical_startup",      &graphical_startup);
 
-    M_BindStringVariable("savedir", &SavePathConfig);
+    M_BindStringVariable("savegames_path",      &SavePathConfig);
+    M_BindStringVariable("screenshots_path",    &ShotPathConfig);
 
     // Multiplayer chat macros
 

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -809,6 +809,9 @@ void D_BindVariables(void)
     M_BindIntVariable("music_volume",           &snd_MusicVolume);
     //M_BindIntVariable("graphical_startup",      &graphical_startup);
 
+    M_BindStringVariable("savegames_path",      &SavePathConfig);
+    M_BindStringVariable("screenshots_path",    &ShotPathConfig);
+
     // Multiplayer chat macros
 
     for (i=0; i<10; ++i)

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -809,9 +809,6 @@ void D_BindVariables(void)
     M_BindIntVariable("music_volume",           &snd_MusicVolume);
     //M_BindIntVariable("graphical_startup",      &graphical_startup);
 
-    M_BindStringVariable("savegames_path",      &SavePathConfig);
-    M_BindStringVariable("screenshots_path",    &ShotPathConfig);
-
     // Multiplayer chat macros
 
     for (i=0; i<10; ++i)

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -87,8 +87,6 @@ boolean autostart;
 
 boolean advancedemo;
 
-static char *SavePathConfig;  // [JN] "savegames_path" config file variable.
-
 void D_ConnectNetGame(void);
 void D_CheckNetGame(void);
 void D_PageDrawer(void);
@@ -828,39 +826,6 @@ void D_BindVariables(void)
 	ID_BindVariables(heretic);
 }
 
-// -----------------------------------------------------------------------------
-// D_SetDefaultSavePath
-// [JN] Set the default directory where savegames are saved.
-// -----------------------------------------------------------------------------
-
-static void D_SetDefaultSavePath (void)
-{
-    // Gather default "savegames" folder location.
-    savegamedir = M_GetSaveGameDir("heretic.wad");
-
-    if (!strcmp(savegamedir, ""))
-    {
-        if (SavePathConfig == NULL || !strcmp(SavePathConfig, ""))
-        {
-            // Config file variable not existing or emptry,
-            // so use generated path from above.
-            savegamedir = M_StringDuplicate("");
-        }
-        else
-        {
-            // Variable existing, use it's path.
-            savegamedir = M_StringDuplicate(SavePathConfig);
-        }
-    }
-
-    // Overwrite config file variable only if following command line
-    // parameters are not present:
-    if (!M_ParmExists("-savedir") && !M_ParmExists("-cdrom"))
-    {
-        SavePathConfig = savegamedir;
-    }
-}
-
 // 
 // Called at exit to display the ENDOOM screen (ENDTEXT in Heretic)
 //
@@ -1274,7 +1239,7 @@ void D_DoomMain(void)
     I_SetWindowTitle(gamedescription);
 
     // [JN] Set the default directory where savegames are saved.
-    D_SetDefaultSavePath();
+    savegamedir = M_GetSaveGameDir("heretic.wad");
 
     // [JN] Set the default directory where screenshots are saved.
     M_SetScreenshotDir();

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -1050,9 +1050,6 @@ void D_DoomMain(void)
     M_SetConfigFilenames(PROGRAM_PREFIX "heretic.ini");
     M_LoadDefaults();
 
-    // [JN] Set screeenshot files dir.
-    M_SetScreenshotDir();
-
     I_AtExit(M_SaveDefaults, true); // [crispy] always save configuration at exit
 
 #ifdef _WIN32
@@ -1278,6 +1275,9 @@ void D_DoomMain(void)
 
     // [JN] Set the default directory where savegames are saved.
     D_SetDefaultSavePath();
+
+    // [JN] Set the default directory where screenshots are saved.
+    M_SetScreenshotDir();
 
     I_PrintStartupBanner(gamedescription);
 

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -87,7 +87,7 @@ boolean autostart;
 
 boolean advancedemo;
 
-static char *SavePathConfig;  // [JN] "savedir" config file variable.
+static char *SavePathConfig;  // [JN] "savegames_path" config file variable.
 
 void D_ConnectNetGame(void);
 void D_CheckNetGame(void);

--- a/src/heretic/d_main.c
+++ b/src/heretic/d_main.c
@@ -87,6 +87,8 @@ boolean autostart;
 
 boolean advancedemo;
 
+static char *SavePathConfig;  // [JN] "savedir" config file variable.
+
 void D_ConnectNetGame(void);
 void D_CheckNetGame(void);
 void D_PageDrawer(void);
@@ -809,6 +811,8 @@ void D_BindVariables(void)
     M_BindIntVariable("music_volume",           &snd_MusicVolume);
     //M_BindIntVariable("graphical_startup",      &graphical_startup);
 
+    M_BindStringVariable("savedir", &SavePathConfig);
+
     // Multiplayer chat macros
 
     for (i=0; i<10; ++i)
@@ -821,6 +825,39 @@ void D_BindVariables(void)
 
 	// [JN] Bind ID-specific config variables.
 	ID_BindVariables(heretic);
+}
+
+// -----------------------------------------------------------------------------
+// D_SetDefaultSavePath
+// [JN] Set the default directory where savegames are saved.
+// -----------------------------------------------------------------------------
+
+static void D_SetDefaultSavePath (void)
+{
+    // Gather default "savegames" folder location.
+    savegamedir = M_GetSaveGameDir("heretic.wad");
+
+    if (!strcmp(savegamedir, ""))
+    {
+        if (SavePathConfig == NULL || !strcmp(SavePathConfig, ""))
+        {
+            // Config file variable not existing or emptry,
+            // so use generated path from above.
+            savegamedir = M_StringDuplicate("");
+        }
+        else
+        {
+            // Variable existing, use it's path.
+            savegamedir = M_StringDuplicate(SavePathConfig);
+        }
+    }
+
+    // Overwrite config file variable only if following command line
+    // parameters are not present:
+    if (!M_ParmExists("-savedir") && !M_ParmExists("-cdrom"))
+    {
+        SavePathConfig = savegamedir;
+    }
 }
 
 // 
@@ -1238,7 +1275,8 @@ void D_DoomMain(void)
 
     I_SetWindowTitle(gamedescription);
 
-    savegamedir = M_GetSaveGameDir("heretic.wad");
+    // [JN] Set the default directory where savegames are saved.
+    D_SetDefaultSavePath();
 
     I_PrintStartupBanner(gamedescription);
 

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -175,9 +175,6 @@ void D_BindVariables(void)
     M_BindIntVariable("sfx_volume",             &snd_MaxVolume);
     M_BindIntVariable("music_volume",           &snd_MusicVolume);
 
-    M_BindStringVariable("savegames_path",      &SavePathConfig);
-    M_BindStringVariable("screenshots_path",    &ShotPathConfig);
-
     // Multiplayer chat macros
 
     for (i=0; i<10; ++i)

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -128,7 +128,7 @@ static int WarpMap;
 static int demosequence;
 static int pagetic;
 static const char *pagename;
-static char *SavePathConfig;
+static char *SavePathConfig;  // [JN] "savegames_path" config file variable.
 
 // CODE --------------------------------------------------------------------
 

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -175,6 +175,9 @@ void D_BindVariables(void)
     M_BindIntVariable("sfx_volume",             &snd_MaxVolume);
     M_BindIntVariable("music_volume",           &snd_MusicVolume);
 
+    M_BindStringVariable("savegames_path",      &SavePathConfig);
+    M_BindStringVariable("screenshots_path",    &ShotPathConfig);
+
     // Multiplayer chat macros
 
     for (i=0; i<10; ++i)

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -441,9 +441,10 @@ void D_DoomMain(void)
     M_SetConfigFilenames(PROGRAM_PREFIX "hexen.ini");
     M_LoadDefaults();
 
+    // [JN] Set the default directory where savegames are saved.
     D_SetDefaultSavePath();
 
-    // [JN] Set screeenshot files dir.
+    // [JN] Set the default directory where screenshots are saved.
     M_SetScreenshotDir();
 
     I_AtExit(M_SaveDefaults, true); // [crispy] always save configuration at exit

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -176,7 +176,8 @@ void D_BindVariables(void)
     M_BindIntVariable("sfx_volume",             &snd_MaxVolume);
     M_BindIntVariable("music_volume",           &snd_MusicVolume);
 
-    M_BindStringVariable("savedir", &SavePathConfig);
+    M_BindStringVariable("savegames_path",      &SavePathConfig);
+    M_BindStringVariable("screenshots_path",    &ShotPathConfig);
 
     // Multiplayer chat macros
 

--- a/src/hexen/h2_main.c
+++ b/src/hexen/h2_main.c
@@ -128,7 +128,6 @@ static int WarpMap;
 static int demosequence;
 static int pagetic;
 static const char *pagename;
-static char *SavePathConfig;  // [JN] "savegames_path" config file variable.
 
 // CODE --------------------------------------------------------------------
 

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -57,7 +57,8 @@ static const char *default_main_config;
 
 // [JN] Location where screenshots are saved.
 
-const char *screenshotdir;
+char *screenshotdir;
+char *ShotPathConfig;
 
 typedef enum 
 {
@@ -130,7 +131,8 @@ static default_t	doom_defaults_list[] =
 
     CONFIG_VARIABLE_STRING(autoload_path),
     CONFIG_VARIABLE_STRING(music_pack_path),
-    CONFIG_VARIABLE_STRING(savedir),
+    CONFIG_VARIABLE_STRING(savegames_path),
+    CONFIG_VARIABLE_STRING(screenshots_path),
 
     //
     // Render
@@ -1225,8 +1227,8 @@ char *M_GetSaveGameDir(const char *iwadname)
     else if (!strcmp(configdir, exedir))
     {
 #ifdef _WIN32
-        // [JN] Check if "savedir" variable is existing in config file.
-        const char *existing_path = M_GetStringVariable("savedir");
+        // [JN] Check if "savegames_path" variable is existing in config file.
+        const char *existing_path = M_GetStringVariable("savegames_path");
 
         if (existing_path != NULL && strlen(existing_path) > 0)
         {
@@ -1310,12 +1312,31 @@ char *M_GetAutoloadDir(const char *iwadname)
 
 void M_SetScreenshotDir (void)
 {
+    int p = M_CheckParmWithArgs("-shotdir", 1);
+
+    if (p)
+    {
+        screenshotdir = myargv[p + 1];
+
+        if (!M_FileExists(screenshotdir))
+        {
+            M_MakeDirectory(screenshotdir);
+        }
+        
+        screenshotdir = M_StringJoin(screenshotdir, DIR_SEPARATOR_S, NULL);
+
+        printf("Screenshot directory changed to %s.\n", screenshotdir);
+    }
+    else
+    {
 #ifdef _WIN32
- 	// [JN] Always use "savegames" folder in program folder.
- 	screenshotdir = M_StringJoin(exedir, "screenshots", DIR_SEPARATOR_S, NULL);
+		// [JN] Always use "savegames" folder in program folder.
+		screenshotdir = M_StringJoin(exedir, "screenshots", DIR_SEPARATOR_S, NULL);
 #else
-    // ~/.local/share/inter-doom/screenshots
-    screenshotdir = M_StringJoin(configdir, "screenshots", DIR_SEPARATOR_S, NULL);
+		// ~/.local/share/inter-doom/screenshots
+		screenshotdir = M_StringJoin(configdir, "screenshots", DIR_SEPARATOR_S, NULL);
 #endif
-    M_MakeDirectory(screenshotdir);
+		M_MakeDirectory(screenshotdir);
+		ShotPathConfig = screenshotdir;
+    }
 }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1211,7 +1211,7 @@ char *M_GetSaveGameDir(const char *iwadname)
         // add separator at end just in case
         savegamedir = M_StringJoin(savegamedir, DIR_SEPARATOR_S, NULL);
 
-        printf("Save directory changed to %s.\n", savegamedir);
+        printf("Save directory changed to %s\n", savegamedir);
     }
 #ifdef _WIN32
     // In -cdrom mode, we write savegames to a specific directory
@@ -1325,7 +1325,7 @@ void M_SetScreenshotDir (void)
         
         screenshotdir = M_StringJoin(screenshotdir, DIR_SEPARATOR_S, NULL);
 
-        printf("Screenshot directory changed to %s.\n", screenshotdir);
+        printf("Screenshot directory changed to %s\n", screenshotdir);
     }
     else
     {

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1349,6 +1349,15 @@ void M_SetScreenshotDir (void)
 
         printf("Screenshot directory changed to %s\n", screenshotdir);
     }
+#ifdef _WIN32
+    // In -cdrom mode, we write screenshots to a specific directory
+    // in addition to configs.
+
+    else if (M_ParmExists("-cdrom"))
+    {
+        screenshotdir = M_StringDuplicate(configdir);
+    }
+#endif
     else
     {
         // [JN] Check if "screenshots_path" variable is existing in config file.
@@ -1362,7 +1371,7 @@ void M_SetScreenshotDir (void)
         else
         {
 #ifdef _WIN32
-            // [JN] Always use "savegames" folder in program folder.
+            // [JN] Always use "screenshots" folder in program folder.
             screenshotdir = M_StringJoin(exedir, "screenshots", NULL);
 #else
             // ~/.local/share/inter-doom/screenshots

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -55,6 +55,10 @@ static char *autoload_path = "";
 
 static const char *default_main_config;
 
+// [JN] "savegames_path" config file variable.
+
+char *SavePathConfig;
+
 // [JN] Location where screenshots are saved.
 
 char *screenshotdir;
@@ -1235,14 +1239,18 @@ char *M_GetSaveGameDir(const char *iwadname)
 
         if (existing_path != NULL && strlen(existing_path) > 0)
         {
-            // It exist, use it's provided path.
-            savegamedir = M_StringDuplicate("");
+            // Variable existing, use it's path.
+            savegamedir = M_StringDuplicate(SavePathConfig);
         }
         else
         {
-            // Otherwise, create and use "savegames" folder in program folder.
-            savegamedir = M_StringJoin(M_StringDuplicate(exedir), "savegames", DIR_SEPARATOR_S, NULL);
+            // Config file variable not existing or emptry, generate a path.
+            savegamedir = M_StringJoin(M_StringDuplicate(exedir), "savegames", NULL);
         }
+
+        // add separator at end just in case
+        savegamedir = M_StringJoin(savegamedir, DIR_SEPARATOR_S, NULL);
+
         M_MakeDirectory(savegamedir);
 #else
 	savegamedir = M_StringDuplicate("");
@@ -1263,6 +1271,13 @@ char *M_GetSaveGameDir(const char *iwadname)
         M_MakeDirectory(savegamedir);
 
         free(topdir);
+    }
+
+    // Overwrite config file variable only if following command line
+    // parameters are not present:
+    if (!M_ParmExists("-savedir") && !M_ParmExists("-cdrom"))
+    {
+        SavePathConfig = savegamedir;
     }
 
     return savegamedir;

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1249,7 +1249,6 @@ char *M_GetSaveGameDir(const char *iwadname)
             // add separator at end just in case
             savegamedir = M_StringJoin(savegamedir, DIR_SEPARATOR_S, NULL);
         }
-
         M_MakeDirectory(savegamedir);
 #else
 	savegamedir = M_StringDuplicate("");
@@ -1347,13 +1346,13 @@ void M_SetScreenshotDir (void)
     else
     {
 #ifdef _WIN32
-		// [JN] Always use "savegames" folder in program folder.
-		screenshotdir = M_StringJoin(exedir, "screenshots", DIR_SEPARATOR_S, NULL);
+ 	// [JN] Always use "savegames" folder in program folder.
+ 	screenshotdir = M_StringJoin(exedir, "screenshots", DIR_SEPARATOR_S, NULL);
 #else
-		// ~/.local/share/inter-doom/screenshots
-		screenshotdir = M_StringJoin(configdir, "screenshots", DIR_SEPARATOR_S, NULL);
+    // ~/.local/share/inter-doom/screenshots
+    screenshotdir = M_StringJoin(configdir, "screenshots", DIR_SEPARATOR_S, NULL);
 #endif
-		M_MakeDirectory(screenshotdir);
-		ShotPathConfig = screenshotdir;
+    M_MakeDirectory(screenshotdir);
+    ShotPathConfig = screenshotdir;
     }
 }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1277,7 +1277,6 @@ char *M_GetSaveGameDir(const char *iwadname)
     if (!M_ParmExists("-savedir") && !M_ParmExists("-cdrom"))
     {
         SavePathConfig = savegamedir;
-        M_BindStringVariable("savegames_path", &SavePathConfig);
     }
 
     return savegamedir;
@@ -1356,6 +1355,5 @@ void M_SetScreenshotDir (void)
 #endif
 		M_MakeDirectory(screenshotdir);
 		ShotPathConfig = screenshotdir;
-		M_BindStringVariable("screenshots_path", &ShotPathConfig);
     }
 }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -1246,10 +1246,9 @@ char *M_GetSaveGameDir(const char *iwadname)
         {
             // Config file variable not existing or emptry, generate a path.
             savegamedir = M_StringJoin(M_StringDuplicate(exedir), "savegames", NULL);
+            // add separator at end just in case
+            savegamedir = M_StringJoin(savegamedir, DIR_SEPARATOR_S, NULL);
         }
-
-        // add separator at end just in case
-        savegamedir = M_StringJoin(savegamedir, DIR_SEPARATOR_S, NULL);
 
         M_MakeDirectory(savegamedir);
 #else
@@ -1278,6 +1277,7 @@ char *M_GetSaveGameDir(const char *iwadname)
     if (!M_ParmExists("-savedir") && !M_ParmExists("-cdrom"))
     {
         SavePathConfig = savegamedir;
+        M_BindStringVariable("savegames_path", &SavePathConfig);
     }
 
     return savegamedir;
@@ -1356,5 +1356,6 @@ void M_SetScreenshotDir (void)
 #endif
 		M_MakeDirectory(screenshotdir);
 		ShotPathConfig = screenshotdir;
+		M_BindStringVariable("screenshots_path", &ShotPathConfig);
     }
 }

--- a/src/m_config.c
+++ b/src/m_config.c
@@ -58,6 +58,9 @@ static const char *default_main_config;
 // [JN] Location where screenshots are saved.
 
 char *screenshotdir;
+
+// [JN] "screenshots_path" config file variable.
+
 char *ShotPathConfig;
 
 typedef enum 

--- a/src/m_config.h
+++ b/src/m_config.h
@@ -41,6 +41,7 @@ char *M_GetAutoloadDir(const char *iwadname);
 void M_SetScreenshotDir (void);
 
 extern const char *configdir;
-extern const char *screenshotdir;
+extern char *screenshotdir;
+extern char *ShotPathConfig;
 
 #endif

--- a/src/m_config.h
+++ b/src/m_config.h
@@ -41,6 +41,7 @@ char *M_GetAutoloadDir(const char *iwadname);
 void M_SetScreenshotDir (void);
 
 extern const char *configdir;
+extern char *SavePathConfig;
 extern char *screenshotdir;
 extern char *ShotPathConfig;
 


### PR DESCRIPTION
Needs some polishing. Probably worth to make `D_SetDefaultSavePath` global for all three games, but it's slightly different for Hexen.

Fixes #125, thanks @liPillON for suggestion!