### PR TITLE
Menu: do not consider mouse movement as button pressing

### DIFF
--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -5509,7 +5509,8 @@ boolean M_Responder (event_t* ev)
     }
     else
     {
-	if (ev->type == ev_mouse && mousewait < I_GetTime())
+	if (ev->type == ev_mouse && mousewait < I_GetTime()
+	&& !ev->data2 && !ev->data3) // [JN] Do not consider movement as pressing.
 	{
 	    // [crispy] mouse_novert disables controlling the menus with the mouse
 	    // [JN] Not needed, as menu is fully controllable by mouse wheel and buttons.

--- a/src/heretic/mn_menu.c
+++ b/src/heretic/mn_menu.c
@@ -5235,7 +5235,8 @@ boolean MN_Responder(event_t * event)
     else
     {
         // [JN] Allow menu control by mouse.
-        if (event->type == ev_mouse && mousewait < I_GetTime())
+        if (event->type == ev_mouse && mousewait < I_GetTime()
+        && !event->data2 && !event->data3) // [JN] Do not consider movement as pressing.
         {
             // [crispy] mouse_novert disables controlling the menus with the mouse
             // [JN] Not needed, as menu is fully controllable by mouse wheel and buttons.

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -4710,7 +4710,8 @@ boolean MN_Responder(event_t * event)
     else
     {
         // [JN] Allow menu control by mouse.
-        if (event->type == ev_mouse && mousewait < I_GetTime())
+        if (event->type == ev_mouse && mousewait < I_GetTime()
+        && !event->data2 && !event->data3) // [JN] Do not consider movement as pressing.
         {
             // [crispy] mouse_novert disables controlling the menus with the mouse
             // [JN] Not needed, as menu is fully controllable by mouse wheel and buttons.


### PR DESCRIPTION
Fixes following case:
* Cursor is placed on any kind of menu items.
* Left mouse button is clicked and being held.
* While button holding, horizontal and/or vertical mouse movement will be registered as button pressing and thus, will activate menu item again while movement.