### PR TITLE
Fix sprite clipping at the edges of the screen in 32:9 ratio

### DIFF
--- a/src/doom/r_local.h
+++ b/src/doom/r_local.h
@@ -706,6 +706,7 @@ extern int     viewwindowy;
 
 // [JN] FOV from DOOM Retro and Nugget Doom
 extern float fovdiff;
+extern fixed_t fovtx;
 
 // [crispy] lookup table for horizontal screen coordinates
 extern int     flipscreenwidth[MAXWIDTH];

--- a/src/doom/r_main.c
+++ b/src/doom/r_main.c
@@ -105,6 +105,9 @@ int			extralight;
 // [JN] FOV from DOOM Retro and Nugget Doom
 static fixed_t fovscale;	
 float  fovdiff;   // [Nugget] Used for some corrections
+// [ceski] [JN] Higher than 21:9 aspect ratios require an extended range
+// of 'tx' value, used by R_ProjectSprite for sprite projection.
+fixed_t fovtx;
 
 // [crispy] parameterized for smooth diminishing lighting
 int LIGHTLEVELS;
@@ -797,6 +800,7 @@ void R_ExecuteSetViewSize (void)
     centerxfrac_nonwide = (viewwidth_nonwide/2)<<FRACBITS;
     // [JN] FOV from DOOM Retro and Nugget Doom
     fovscale = finetangent[(int)(FINEANGLES / 4 + (vid_fov + WIDEFOVDELTA) * FINEANGLES / 360 / 2)];
+    fovtx = (vid_widescreen > 4 && vid_fov >= 90) ? 4 : 2;
     projection = FixedDiv(centerxfrac, fovscale);
 
     if (!detailshift)

--- a/src/doom/r_things.c
+++ b/src/doom/r_things.c
@@ -601,7 +601,8 @@ static void R_ProjectSprite (mobj_t* thing)
     tx = -(gyt+gxt); 
 
     // too far off the side?
-    if (abs(tx)>(tz<<2))
+    // [ceski] [JN] Possibly use an extended value (fovtx) and prevent overflows (int64_t).
+    if ((int64_t)(abs(tx) >> fovtx) > (abs(tz)))
 	return;
     
     // decide which patch to use for sprite relative to player


### PR DESCRIPTION
@ceski-1, something like this, for better view. I made couple of experiments, and in the end, such correction is needed even for `90` FOV (`vid_fov >= 90`) to prevent disappearing edge pixels of huge sprites like Spider Mastermind.

Still, looks likes even vanilla `<<2` isn't optimal, as acording to simple `printf(".");` sprite may still run through projection code even if it's totally out of screen, but fortunately, it's still get reject by `return`'s few lines of code below. How to make it more precise? Really no idea.

I've also checked framerate and amount of rendered vissprites at Camatose - looks likes there is no difference at all.

A testing map I was using: [fovclip.zip](https://github.com/user-attachments/files/16043818/fovclip.zip)
