### PR TITLE
Small memory optimizations

### DIFF
--- a/src/doom/f_wipe.c
+++ b/src/doom/f_wipe.c
@@ -17,6 +17,7 @@
 //	Mission begin melt/wipe screen special effect.
 //
 
+#include <stdlib.h>
 #include <string.h>
 
 #include "z_zone.h"
@@ -51,7 +52,7 @@ static int fade_counter;
 static void wipe_shittyColMajorXform (dpixel_t *array)
 {
     const int width = SCREENWIDTH/2;
-    dpixel_t *dest = (dpixel_t*) Z_Malloc(width*SCREENHEIGHT*sizeof(*dest), PU_STATIC, 0);
+    dpixel_t *dest = (dpixel_t*) malloc(width*SCREENHEIGHT*sizeof(*dest));
 
     for (int y = 0 ; y < SCREENHEIGHT ; y++)
     {
@@ -63,7 +64,7 @@ static void wipe_shittyColMajorXform (dpixel_t *array)
 
     memcpy(array, dest, width*SCREENHEIGHT*sizeof(*dest));
 
-    Z_Free(dest);
+    free(dest);
 }
 
 // -----------------------------------------------------------------------------
@@ -82,7 +83,7 @@ static void wipe_initMelt (void)
 
     // setup initial column positions
     // (y<0 => not ready to scroll yet)
-    y = (int *) Z_Malloc(SCREENWIDTH*sizeof(int), PU_STATIC, 0);
+    y = (int *) malloc(SCREENWIDTH*sizeof(int));
     y[0] = -(ID_RealRandom()%16);
 
     for (int i = 1 ; i < SCREENWIDTH ; i++)
@@ -236,9 +237,9 @@ static const int wipe_doCrossfade (const int ticks)
 static void wipe_exit (void)
 {
     if (vid_screenwipe < 3)  // [JN] y is not allocated in crossfade wipe.
-    Z_Free(y);
-    Z_Free(wipe_scr_start);
-    Z_Free(wipe_scr_end);
+    free(y);
+    free(wipe_scr_start);
+    free(wipe_scr_end);
 }
 
 // -----------------------------------------------------------------------------
@@ -247,7 +248,7 @@ static void wipe_exit (void)
 
 void wipe_StartScreen (void)
 {
-    wipe_scr_start = Z_Malloc(SCREENWIDTH * SCREENHEIGHT * sizeof(*wipe_scr_start), PU_STATIC, NULL);
+    wipe_scr_start = malloc(SCREENWIDTH * SCREENHEIGHT * sizeof(*wipe_scr_start));
     I_ReadScreen(wipe_scr_start);
 }
 
@@ -257,7 +258,7 @@ void wipe_StartScreen (void)
 
 void wipe_EndScreen (void)
 {
-    wipe_scr_end = Z_Malloc(SCREENWIDTH * SCREENHEIGHT * sizeof(*wipe_scr_end), PU_STATIC, NULL);
+    wipe_scr_end = malloc(SCREENWIDTH * SCREENHEIGHT * sizeof(*wipe_scr_end));
     I_ReadScreen(wipe_scr_end);
     V_DrawBlock(0, 0, SCREENWIDTH, SCREENHEIGHT, wipe_scr_start); // restore start scr.
 }

--- a/src/doom/r_data.c
+++ b/src/doom/r_data.c
@@ -1467,8 +1467,8 @@ void R_PrecacheLevel (void)
     }
 
     {
-        size_t size = numflats > numsprites   ? numflats : numsprites;
-        hitlist = Z_Malloc(numtextures > size ? numtextures : size, PU_STATIC, 0);
+        const size_t size = numflats > numsprites ? numflats : numsprites;
+        hitlist = malloc(numtextures > size ? numtextures : size);
     }
 
     // Precache flats.
@@ -1555,7 +1555,7 @@ void R_PrecacheLevel (void)
         }
     }
 
-    Z_Free(hitlist);
+    free(hitlist);
 }
 
 

--- a/src/doom/r_draw.c
+++ b/src/doom/r_draw.c
@@ -21,6 +21,7 @@
 
 
 
+#include <stdlib.h>
 
 #include "doomdef.h"
 #include "deh_main.h"
@@ -1048,7 +1049,7 @@ R_InitBuffer
 
     if (background_buffer != NULL)
     {
-	    Z_Free(background_buffer);
+	    free(background_buffer);
 	    background_buffer = NULL;
     }
 } 
@@ -1083,7 +1084,7 @@ void R_FillBackScreen (void)
     if (background_buffer == NULL)
     {
         const int size = SCREENWIDTH * (SCREENHEIGHT - SBARHEIGHT);
-        background_buffer = Z_Malloc(size * sizeof(*background_buffer), PU_STATIC, NULL);
+        background_buffer = malloc(size * sizeof(*background_buffer));
     }
 
     // Draw screen and bezel; this is done to a separate screen buffer.
@@ -1167,7 +1168,7 @@ void R_DrawViewBorder (void)
     int		ofs;
     int		i; 
  
-    if (scaledviewwidth == SCREENWIDTH) 
+    if (scaledviewwidth == SCREENWIDTH || background_buffer == NULL) 
 	return; 
   
     top = ((SCREENHEIGHT-SBARHEIGHT)-viewheight)/2; 

--- a/src/heretic/f_wipe.c
+++ b/src/heretic/f_wipe.c
@@ -14,6 +14,7 @@
 // GNU General Public License for more details.
 //
 
+#include <stdlib.h>
 #include <string.h>
 
 #include "z_zone.h"
@@ -108,8 +109,8 @@ static void wipe_exit (void)
 {
     // [JN] Blit final screen.
     V_DrawBlock(0, 0, SCREENWIDTH, SCREENHEIGHT, wipe_scr_end);
-    Z_Free(wipe_scr_start);
-    Z_Free(wipe_scr_end);
+    free(wipe_scr_start);
+    free(wipe_scr_end);
 }
 
 // -----------------------------------------------------------------------------
@@ -118,7 +119,7 @@ static void wipe_exit (void)
 
 void wipe_StartScreen (void)
 {
-    wipe_scr_start = Z_Malloc(SCREENWIDTH * SCREENHEIGHT * sizeof(*wipe_scr_start), PU_STATIC, NULL);
+    wipe_scr_start = malloc(SCREENWIDTH * SCREENHEIGHT * sizeof(*wipe_scr_start));
     I_ReadScreen(wipe_scr_start);
 }
 
@@ -128,7 +129,7 @@ void wipe_StartScreen (void)
 
 void wipe_EndScreen (void)
 {
-    wipe_scr_end = Z_Malloc(SCREENWIDTH * SCREENHEIGHT * sizeof(*wipe_scr_end), PU_STATIC, NULL);
+    wipe_scr_end = malloc(SCREENWIDTH * SCREENHEIGHT * sizeof(*wipe_scr_end));
     I_ReadScreen(wipe_scr_end);
 }
 

--- a/src/heretic/r_draw.c
+++ b/src/heretic/r_draw.c
@@ -16,6 +16,7 @@
 //
 // R_draw.c
 
+#include <stdlib.h>
 #include "doomdef.h"
 #include "deh_str.h"
 #include "r_local.h"
@@ -826,7 +827,7 @@ void R_InitBuffer(int width, int height)
 
     if (background_buffer != NULL)
     {
-        Z_Free(background_buffer);
+        free(background_buffer);
         background_buffer = NULL;
     }
 }
@@ -858,7 +859,7 @@ void R_FillBackScreen (void)
 	if (background_buffer == NULL)
 	{
 		const int size = SCREENWIDTH * (SCREENHEIGHT - SBARHEIGHT);
-		background_buffer = Z_Malloc(size * sizeof(*background_buffer), PU_STATIC, NULL);
+		background_buffer = malloc(size * sizeof(*background_buffer));
 	}
 
 	// Draw screen and bezel; this is done to a separate screen buffer.
@@ -924,7 +925,7 @@ void R_DrawViewBorder (void)
 	int ofs;
 	int i; 
     
-	if (scaledviewwidth == SCREENWIDTH)
+	if (scaledviewwidth == SCREENWIDTH || background_buffer == NULL)
 	{
 		return;
 	}

--- a/src/hexen/f_wipe.c
+++ b/src/hexen/f_wipe.c
@@ -14,6 +14,7 @@
 // GNU General Public License for more details.
 //
 
+#include <stdlib.h>
 #include <string.h>
 
 #include "z_zone.h"
@@ -112,8 +113,8 @@ static void wipe_exit (void)
 {
     // [JN] Blit final screen.
     V_DrawBlock(0, 0, SCREENWIDTH, SCREENHEIGHT, wipe_scr_end);
-    Z_Free(wipe_scr_start);
-    Z_Free(wipe_scr_end);
+    free(wipe_scr_start);
+    free(wipe_scr_end);
 }
 
 // -----------------------------------------------------------------------------
@@ -122,7 +123,7 @@ static void wipe_exit (void)
 
 void wipe_StartScreen (void)
 {
-    wipe_scr_start = Z_Malloc(SCREENWIDTH * SCREENHEIGHT * sizeof(*wipe_scr_start), PU_STATIC, NULL);
+    wipe_scr_start = malloc(SCREENWIDTH * SCREENHEIGHT * sizeof(*wipe_scr_start));
     I_ReadScreen(wipe_scr_start);
 }
 
@@ -132,7 +133,7 @@ void wipe_StartScreen (void)
 
 void wipe_EndScreen (void)
 {
-    wipe_scr_end = Z_Malloc(SCREENWIDTH * SCREENHEIGHT * sizeof(*wipe_scr_end), PU_STATIC, NULL);
+    wipe_scr_end = malloc(SCREENWIDTH * SCREENHEIGHT * sizeof(*wipe_scr_end));
     I_ReadScreen(wipe_scr_end);
 }
 

--- a/src/hexen/r_draw.c
+++ b/src/hexen/r_draw.c
@@ -16,6 +16,7 @@
 //
 
 
+#include <stdlib.h>
 #include "h2def.h"
 #include "i_system.h"
 #include "i_video.h"
@@ -732,7 +733,7 @@ void R_InitBuffer(int width, int height)
 
     if (background_buffer != NULL)
     {
-        Z_Free(background_buffer);
+        free(background_buffer);
         background_buffer = NULL;
     }
 }
@@ -765,7 +766,7 @@ void R_FillBackScreen (void)
 	if (background_buffer == NULL)
 	{
 		const int size = SCREENWIDTH * (SCREENHEIGHT - SBARHEIGHT);
-		background_buffer = Z_Malloc(size * sizeof(*background_buffer), PU_STATIC, NULL);
+		background_buffer = malloc(size * sizeof(*background_buffer));
 	}
 
 	// Draw screen and bezel; this is done to a separate screen buffer.
@@ -826,7 +827,7 @@ void R_DrawViewBorder (void)
 	// [JN] Attempt to round up precision problem.
 	int yy2 = 3, yy3 = 2;
     
-	if (scaledviewwidth == SCREENWIDTH)
+	if (scaledviewwidth == SCREENWIDTH || background_buffer == NULL)
 	{
 		return;
 	}


### PR DESCRIPTION
Not exactly _optimizations_, just a little bit of _de-consumption_. This does the following:

* Screen wipe effect. Needs allocated memory to perform, but once done, no need to hold it as a purgable hostage.
* Screen border. Mostly the same as above.

But in the end all this is a matter of 2-15 megabytes, depending on the rendering resolution.