### PR TITLE
Rewrote and simplify smooth palette changing

### DIFF
--- a/src/doom/p_inter.c
+++ b/src/doom/p_inter.c
@@ -33,7 +33,6 @@
 #include "id_func.h"
 
 
-#define BONUSADD	(vis_smooth_palette ? 8 : 6)  // [JN] Smooth palette.
 
 
 
@@ -190,7 +189,6 @@ P_GiveWeapon
 	    return false;
 
 	player->bonuscount += BONUSADD;
-	yel_pane_alpha += player->bonuscount;  // [JN] Smooth palette.
 	player->weaponowned[weapon] = true;
 
 	if (deathmatch)
@@ -294,7 +292,6 @@ P_GiveCard
 	return;
     
     player->bonuscount += netgame ? BONUSADD : 0; // [crispy] Fix "Key pickup resets palette"
-    yel_pane_alpha += player->bonuscount;  // [JN] Smooth palette.
     player->cards[card] = 1;
 }
 
@@ -705,7 +702,6 @@ P_TouchSpecialThing
     P_RemoveMobj (special);
 
     player->bonuscount += BONUSADD;
-    yel_pane_alpha += player->bonuscount;  // [JN] Smooth palette.
     // [JN] Limit bonus palette duration to 4 seconds.
     if (player->bonuscount > 4 * TICRATE)
 	player->bonuscount = 4 * TICRATE;

--- a/src/doom/p_local.h
+++ b/src/doom/p_local.h
@@ -300,6 +300,9 @@ extern result_e T_MovePlane (sector_t *sector, fixed_t speed, fixed_t dest,
 // P_INTER
 // -----------------------------------------------------------------------------
 
+#define BONUSADD    6  // [JN] Externalized for smooth fading.
+#define PAINADD     4  // [JN] Paint palette multiplier for smooth fading.
+
 extern boolean P_GivePower(player_t*, int);
 extern void    P_TouchSpecialThing (mobj_t *special, mobj_t *toucher);
 extern void    P_DamageMobj (mobj_t *target, mobj_t *inflictor, mobj_t *source, int damage);

--- a/src/doom/p_local.h
+++ b/src/doom/p_local.h
@@ -301,7 +301,7 @@ extern result_e T_MovePlane (sector_t *sector, fixed_t speed, fixed_t dest,
 // -----------------------------------------------------------------------------
 
 #define BONUSADD    6  // [JN] Externalized for smooth fading.
-#define PAINADD     4  // [JN] Paint palette multiplier for smooth fading.
+#define PAINADD     4  // [JN] Pain palette multiplier for smooth fading.
 
 extern boolean P_GivePower(player_t*, int);
 extern void    P_TouchSpecialThing (mobj_t *special, mobj_t *toucher);

--- a/src/doom/p_user.c
+++ b/src/doom/p_user.c
@@ -287,7 +287,6 @@ void P_DeathThink (player_t* player)
 
 	    if (player->damagecount)
 	    {
-		red_pane_alpha = player->damagecount * 4;  // [JN] Smooth palette.
 		player->damagecount--;
 	    }
 	}
@@ -298,7 +297,6 @@ void P_DeathThink (player_t* player)
     }
     else if (player->damagecount)
     {
-	red_pane_alpha = player->damagecount * 4;  // [JN] Smooth palette.
 	player->damagecount--;
     }
 	
@@ -517,13 +515,11 @@ void P_PlayerThink (player_t* player)
 		
     if (player->damagecount)
     {
-	red_pane_alpha = player->damagecount * 4;  // [JN] Smooth palette.
 	player->damagecount--;
     }
 		
     if (player->bonuscount)
     {
-	yel_pane_alpha = player->bonuscount * 4;  // [JN] Smooth palette.
 	player->bonuscount--;
     }
 

--- a/src/doom/st_bar.c
+++ b/src/doom/st_bar.c
@@ -996,33 +996,30 @@ static void ST_doSmoothPaletteStuff (void)
     int palette;
     int red = plyr->damagecount;
     int yel = plyr->bonuscount;
+    int grn = plyr->powers[pw_ironfeet] > 4*32 || plyr->powers[pw_ironfeet] & 8;
 
     if (plyr->powers[pw_strength])
     {
         // slowly fade the berzerk out
-        const int bzc = 12 - (plyr->powers[pw_strength] >> 6);
-        red_pane_alpha = plyr->powers[pw_strength];
+        const int bzc = (12 << 1) - (plyr->powers[pw_strength] >> (6 - 1));
 
         if (bzc > red)
         {
             red = bzc;
-            red_pane_alpha = bzc * 8;
-        }
-        else
-        {
-            red_pane_alpha = red * 4;
         }
     }
 
     if (red)
     {
         palette = 1;
+        red_pane_alpha = MIN(red * PAINADD, 226);   // 226 pane alpha max
     }
     else if (yel)
     {
         palette = 9;
+        yel_pane_alpha = MIN(yel * BONUSADD, 127);  // 127 pane alpha max
     }
-    else if (plyr->powers[pw_ironfeet] > 4*32 || plyr->powers[pw_ironfeet] & 8)
+    else if (grn)
     {
         palette = RADIATIONPAL;
     }

--- a/src/heretic/p_enemy.c
+++ b/src/heretic/p_enemy.c
@@ -2651,7 +2651,6 @@ void A_SkullPop(mobj_t *actor, player_t *player_, pspdef_t *psp)
         player->mo = mo;
         player->lookdir = 0;
         player->damagecount = 32;
-        red_pane_alpha = player->damagecount * 4;  // [JN] Smooth palette.
     }
 }
 

--- a/src/heretic/p_inter.c
+++ b/src/heretic/p_inter.c
@@ -30,7 +30,6 @@
 #include "id_vars.h"
 
 
-#define BONUSADD (vis_smooth_palette ? 8 : 6)  // [JN] Smooth palette.
 
 int WeaponValue[] = {
     1,                          // staff
@@ -224,7 +223,6 @@ boolean P_GiveWeapon(player_t * player, weapontype_t weapon)
             return (false);
         }
         player->bonuscount += BONUSADD;
-        yel_pane_alpha += player->bonuscount;  // [JN] Smooth palette.
         player->weaponowned[weapon] = true;
         P_GiveAmmo(player, wpnlev1info[weapon].ammo, GetWeaponAmmo[weapon]);
         player->pendingweapon = weapon;
@@ -328,7 +326,6 @@ void P_GiveKey(player_t * player, keytype_t key)
         KeyPoints[key].y = 0;
     }
     player->bonuscount = BONUSADD;
-    yel_pane_alpha += player->bonuscount;  // [JN] Smooth palette.
     player->keys[key] = true;
 }
 
@@ -873,7 +870,6 @@ void P_TouchSpecialThing(mobj_t * special, mobj_t * toucher)
         P_RemoveMobj(special);
     }
     player->bonuscount += BONUSADD;
-    yel_pane_alpha += player->bonuscount;  // [JN] Smooth palette.
     // [JN] Limit bonus palette duration to 4 seconds.
     if (player->bonuscount > 4 * TICRATE)
     {

--- a/src/heretic/p_local.h
+++ b/src/heretic/p_local.h
@@ -268,7 +268,7 @@ extern mobj_t **blocklinks;     // for thing chains
 // ***** P_INTER *****
 
 #define BONUSADD 6  // [JN] Externalized for smooth fading.
-#define PAINADD  4  // [JN] Paint palette multiplier for smooth fading.
+#define PAINADD  4  // [JN] Pain palette multiplier for smooth fading.
 
 extern int maxammo[NUMAMMO];
 extern int clipammo[NUMAMMO];

--- a/src/heretic/p_local.h
+++ b/src/heretic/p_local.h
@@ -267,6 +267,9 @@ extern mobj_t **blocklinks;     // for thing chains
 
 // ***** P_INTER *****
 
+#define BONUSADD 6  // [JN] Externalized for smooth fading.
+#define PAINADD  4  // [JN] Paint palette multiplier for smooth fading.
+
 extern int maxammo[NUMAMMO];
 extern int clipammo[NUMAMMO];
 

--- a/src/heretic/p_user.c
+++ b/src/heretic/p_user.c
@@ -427,7 +427,6 @@ void P_DeathThink(player_t * player)
             player->mo->angle = angle;
             if (player->damagecount)
             {
-                red_pane_alpha = player->damagecount * 4;  // [JN] Smooth palette.
                 player->damagecount--;
             }
         }
@@ -438,7 +437,6 @@ void P_DeathThink(player_t * player)
     }
     else if (player->damagecount)
     {
-        red_pane_alpha = player->damagecount * 4;  // [JN] Smooth palette.
         player->damagecount--;
     }
 
@@ -826,12 +824,10 @@ void P_PlayerThink(player_t * player)
     }
     if (player->damagecount)
     {
-        red_pane_alpha = player->damagecount * 4;  // [JN] Smooth palette.
         player->damagecount--;
     }
     if (player->bonuscount)
     {
-        yel_pane_alpha = player->bonuscount * 4;  // [JN] Smooth palette.
         player->bonuscount--;
     }
     // Colormaps

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -1233,16 +1233,22 @@ void SB_PaletteFlash(void)
 void SB_SmoothPaletteFlash (void)
 {
     int palette;
+    int red;
+    int yel;
 
     CPlayer = &players[displayplayer];
+    red = CPlayer->damagecount;
+    yel = CPlayer->bonuscount;
 
     if (CPlayer->damagecount)
     {
         palette = 1;
+        red_pane_alpha = MIN(red * PAINADD, 226);   // 226 pane alpha max
     }
     else if (CPlayer->bonuscount)
     {
         palette = 9;
+        yel_pane_alpha = MIN(yel * BONUSADD, 127);  // 127 pane alpha max
     }
     else
     {

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -1233,22 +1233,18 @@ void SB_PaletteFlash(void)
 void SB_SmoothPaletteFlash (void)
 {
     int palette;
-    int red;
-    int yel;
 
     CPlayer = &players[displayplayer];
-    red = CPlayer->damagecount;
-    yel = CPlayer->bonuscount;
 
     if (CPlayer->damagecount)
     {
         palette = 1;
-        red_pane_alpha = MIN(red * PAINADD, 226);   // 226 pane alpha max
+        red_pane_alpha = MIN(CPlayer->damagecount * PAINADD, 226);   // 226 pane alpha max
     }
     else if (CPlayer->bonuscount)
     {
         palette = 9;
-        yel_pane_alpha = MIN(yel * BONUSADD, 127);  // 127 pane alpha max
+        yel_pane_alpha = MIN(CPlayer->bonuscount * BONUSADD, 127);  // 127 pane alpha max
     }
     else
     {

--- a/src/hexen/p_enemy.c
+++ b/src/hexen/p_enemy.c
@@ -1844,7 +1844,6 @@ void A_SkullPop(mobj_t *actor, player_t *player_, pspdef_t *psp)
     player->mo = mo;
     player->lookdir = 0;
     player->damagecount = 32;
-    red_pane_alpha = player->damagecount * 4;  // [JN] Smooth palette.
 }
 
 //----------------------------------------------------------------------------

--- a/src/hexen/p_inter.c
+++ b/src/hexen/p_inter.c
@@ -28,7 +28,6 @@
 #include "id_vars.h"
 
 
-#define BONUSADD (vis_smooth_palette ? 8 : 6)  // [JN] Smooth palette.
 
 int ArmorIncrement[NUMCLASSES][NUMARMOR] = {
     {25 * FRACUNIT, 20 * FRACUNIT, 15 * FRACUNIT, 5 * FRACUNIT},
@@ -225,7 +224,6 @@ static void TryPickupWeapon(player_t * player, pclass_t weaponClass,
     }
 
     player->bonuscount += BONUSADD;
-    yel_pane_alpha += player->bonuscount;  // [JN] Smooth palette.
     // [JN] Limit bonus palette duration to 4 seconds.
     if (player->bonuscount > 4 * TICRATE)
     {
@@ -435,7 +433,6 @@ static void TryPickupWeaponPiece(player_t * player, pclass_t matchClass,
         }
     }
     player->bonuscount += BONUSADD;
-    yel_pane_alpha += player->bonuscount;  // [JN] Smooth palette.
 
     // Check if fourth weapon assembled
     if (checkAssembled)
@@ -553,7 +550,6 @@ int P_GiveKey(player_t * player, keytype_t key)
         return false;
     }
     player->bonuscount += BONUSADD;
-    yel_pane_alpha += player->bonuscount;  // [JN] Smooth palette.
     player->keys |= 1 << key;
     return true;
 }
@@ -702,7 +698,6 @@ static void TryPickupArtifact(player_t * player, artitype_t artifactType,
             artifact->special = 0;
         }
         player->bonuscount += BONUSADD;
-        yel_pane_alpha += player->bonuscount;  // [JN] Smooth palette.
         if (artifactType < arti_firstpuzzitem)
         {
             SetDormantArtifact(artifact);
@@ -966,7 +961,6 @@ void P_TouchSpecialThing(mobj_t * special, mobj_t * toucher)
                 break;
             }
             player->bonuscount += BONUSADD;
-            yel_pane_alpha += player->bonuscount;  // [JN] Smooth palette.
             if (player == &players[consoleplayer])
             {
                 S_StartSound(NULL, sound);
@@ -1180,7 +1174,6 @@ void P_TouchSpecialThing(mobj_t * special, mobj_t * toucher)
         P_RemoveMobj(special);
     }
     player->bonuscount += BONUSADD;
-    yel_pane_alpha += player->bonuscount;  // [JN] Smooth palette.
     if (player == &players[consoleplayer])
     {
         S_StartSound(NULL, sound);

--- a/src/hexen/p_local.h
+++ b/src/hexen/p_local.h
@@ -325,6 +325,10 @@ extern mobj_t **blocklinks;     // for thing chains
 
 // ***** P_INTER *****
 
+#define BONUSADD    6  // [JN] Externalized for smooth fading.
+#define PAINADD     4  // [JN] Pain palette multiplier for smooth fading.
+#define POISONADD   5  // [JN] Poison palette multiplier for smooth fading.
+
 extern int clipmana[NUMMANA];
 extern int ArmorIncrement[NUMCLASSES][NUMARMOR];
 extern int AutoArmorSave[NUMCLASSES];

--- a/src/hexen/p_user.c
+++ b/src/hexen/p_user.c
@@ -431,12 +431,10 @@ void P_DeathThink(player_t * player)
         {                       // Looking at killer, so fade damage and poison counters
             if (player->damagecount)
             {
-                red_pane_alpha = player->damagecount * 4;  // [JN] Smooth palette.
                 player->damagecount--;
             }
             if (player->poisoncount)
             {
-                grn_pane_alpha = player->poisoncount * 5;  // [JN] Smooth palette.
                 player->poisoncount--;
             }
         }
@@ -458,12 +456,10 @@ void P_DeathThink(player_t * player)
     {
         if (player->damagecount)
         {
-            red_pane_alpha = player->damagecount * 4;  // [JN] Smooth palette.
             player->damagecount--;
         }
         else
         {
-            grn_pane_alpha = player->poisoncount * 5;  // [JN] Smooth palette.
             player->poisoncount--;
         }
     }
@@ -1012,12 +1008,10 @@ void P_PlayerThink(player_t * player)
     }
     if (player->damagecount)
     {
-        red_pane_alpha = player->damagecount * 4;  // [JN] Smooth palette.
         player->damagecount--;
     }
     if (player->bonuscount)
     {
-        yel_pane_alpha = player->bonuscount * 4;  // [JN] Smooth palette.
         player->bonuscount--;
     }
     if (player->poisoncount && !(leveltime & 15))
@@ -1027,7 +1021,6 @@ void P_PlayerThink(player_t * player)
         {
             player->poisoncount = 0;
         }
-        grn_pane_alpha = player->poisoncount * 5;  // [JN] Smooth palette.
         P_PoisonDamage(player, player->poisoner, 1, true);
     }
     // Colormaps

--- a/src/hexen/sb_bar.c
+++ b/src/hexen/sb_bar.c
@@ -1319,14 +1319,17 @@ void SB_SmoothPaletteFlash (boolean forceChange)
         if (CPlayer->poisoncount)
         {
             palette = 14;
+            grn_pane_alpha = MIN(CPlayer->poisoncount * POISONADD, 204); // 204 pane alpha max
         }
         else if (CPlayer->damagecount)
         {
             palette = 1;
+            red_pane_alpha = MIN(CPlayer->damagecount * PAINADD, 226);   // 226 pane alpha max
         }
         else if (CPlayer->bonuscount)
         {
             palette = 9;
+            yel_pane_alpha = MIN(CPlayer->bonuscount * BONUSADD, 127);   // 127 pane alpha max
         }
         else if (CPlayer->mo->flags2 & MF2_ICEDAMAGE)
         {                       // Frozen player

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1099,7 +1099,7 @@ void I_SetPalette (int palette)
 	    if (vis_smooth_palette)
 	    {
 	    curpane = redpane;
-	    pane_alpha = MIN(red_pane_alpha, 226);
+	    pane_alpha = red_pane_alpha;
 	    break;
 	    }
 	case 2:
@@ -1116,7 +1116,7 @@ void I_SetPalette (int palette)
 	    if (vis_smooth_palette)
 	    {
 	    curpane = yelpane;
-	    pane_alpha = MIN(yel_pane_alpha, 127);
+	    pane_alpha = yel_pane_alpha;
 	    break;
 	    }
 	case 10:

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1135,7 +1135,7 @@ void I_SetPalette (int palette)
 	    curpane = grnspane;
 	    if (vis_smooth_palette)
 	    {
-	    pane_alpha = MIN(grn_pane_alpha, 204);
+	    pane_alpha = grn_pane_alpha;
 	    }
 	    else
 	    {


### PR DESCRIPTION
* No need to perform pane alpha value operations over the game state code. Let the gametic-based palette handler calculate it and pass it to the renderer.
* Such approach should be more accurate, comparing to original one.