### PR TITLE
Hexen: smooth palette fading for Wraithwerge and Bloodscourge

### DIFF
--- a/src/hexen/g_game.c
+++ b/src/hexen/g_game.c
@@ -1916,6 +1916,8 @@ void G_PlayerExitMap(int playerNumber)
     player->damagecount = 0;    // No palette changes
     player->bonuscount = 0;
     player->poisoncount = 0;
+    // [JN] Reset smooth palette fading for Wraithwerge and Bloodscourge.
+    player->graycount = player->orngcount = 0;
     if (player == &players[consoleplayer])
     {
         SB_state = -1;          // refresh the status bar

--- a/src/hexen/h2def.h
+++ b/src/hexen/h2def.h
@@ -604,6 +604,7 @@ typedef struct player_s
 
     int damagecount, bonuscount;        // for screen flashing
     int poisoncount;            // screen flash for poison damage
+    int graycount, orngcount;   // [JN] Smooth palette fading for Wraithwerge and Bloodscourge.
     mobj_t *poisoner;           // NULL for non-player mobjs
     mobj_t *attacker;           // who did damage (NULL for floors)
     int extralight;             // so gun flashes light up areas

--- a/src/hexen/mn_menu.c
+++ b/src/hexen/mn_menu.c
@@ -3106,6 +3106,15 @@ static void M_ID_SmoothPalette (int choice)
     return;
 #else
     vis_smooth_palette ^= 1;
+    // [JN] Properly handle current palette effect.
+    if (vis_smooth_palette)
+    {
+        SB_SmoothPaletteFlash(true);
+    }
+    else
+    {
+        SB_PaletteFlash(true);
+    }
 #endif
 }
 

--- a/src/hexen/p_mobj.c
+++ b/src/hexen/p_mobj.c
@@ -1444,6 +1444,8 @@ void P_SpawnPlayer(mapthing_t * mthing)
     p->damagecount = 0;
     p->bonuscount = 0;
     p->poisoncount = 0;
+    // [JN] Reset smooth palette fading for Wraithwerge and Bloodscourge.
+    p->graycount = p->orngcount = 0;
     p->morphTics = 0;
     p->extralight = 0;
     p->fixedcolormap = 0;

--- a/src/hexen/p_pspr.c
+++ b/src/hexen/p_pspr.c
@@ -1193,6 +1193,8 @@ void A_MStaffAttack(mobj_t *actor, player_t *player, pspdef_t *psp)
                                              PU_CACHE) +
                      STARTSCOURGEPAL * 768);
 #else
+        player->orngcount = 127;  // [JN] 127 pane alpha max
+        if (!vis_smooth_palette)  // [JN] Smooth palette.
         I_SetPalette(STARTSCOURGEPAL);
 #endif
     }
@@ -1219,6 +1221,7 @@ void A_MStaffPalette(mobj_t *actor, player_t *player, pspdef_t *psp)
         I_SetPalette((byte *) W_CacheLumpNum(W_GetNumForName("playpal"),
                                              PU_CACHE) + pal * 768);
 #else
+        if (!vis_smooth_palette)  // [JN] Smooth palette.
         I_SetPalette(pal);
 #endif
     }
@@ -1942,6 +1945,8 @@ void A_CHolyAttack(mobj_t *actor, player_t *player, pspdef_t *psp)
         I_SetPalette((byte *) W_CacheLumpNum(W_GetNumForName("playpal"),
                                              PU_CACHE) + STARTHOLYPAL * 768);
 #else
+        player->graycount = 127;  // [JN] 127 pane alpha max
+        if (!vis_smooth_palette)  // [JN] Smooth palette.
         I_SetPalette(STARTHOLYPAL);
 #endif
     }
@@ -1969,6 +1974,7 @@ void A_CHolyPalette(mobj_t *actor, player_t *player, pspdef_t *psp)
         I_SetPalette((byte *) W_CacheLumpNum(W_GetNumForName("playpal"),
                                              PU_CACHE) + pal * 768);
 #else
+        if (!vis_smooth_palette)  // [JN] Smooth palette.
         I_SetPalette(pal);
 #endif
     }

--- a/src/hexen/p_user.c
+++ b/src/hexen/p_user.c
@@ -1023,6 +1023,18 @@ void P_PlayerThink(player_t * player)
         }
         P_PoisonDamage(player, player->poisoner, 1, true);
     }
+
+    // [JN] Smooth palette fading for Cleric's Wraithwerge and Mage's Bloodscourge.
+    if (player->graycount)
+    {
+        player->graycount -= 12;
+        player->graycount = MAX(0, player->graycount);
+    }
+    if (player->orngcount)
+    {
+        player->orngcount -= 12;
+        player->orngcount = MAX(0, player->orngcount);
+    }
     // Colormaps
 //      if(player->powers[pw_invulnerability])
 //      {

--- a/src/hexen/sb_bar.c
+++ b/src/hexen/sb_bar.c
@@ -1331,6 +1331,16 @@ void SB_SmoothPaletteFlash (boolean forceChange)
             palette = 9;
             yel_pane_alpha = MIN(CPlayer->bonuscount * BONUSADD, 127);   // 127 pane alpha max
         }
+        else if (CPlayer->graycount)
+        {
+            palette = 22;  // STARTHOLYPAL
+            gray_pane_alpha = CPlayer->graycount;  // 127 pane alpha max set in A_CHolyAttack
+        }
+        else if (CPlayer->orngcount)
+        {
+            palette = 25;  // STARTSCOURGEPAL
+            orng_pane_alpha = CPlayer->orngcount;  // 127 pane alpha max set in A_MStaffAttack
+        }
         else if (CPlayer->mo->flags2 & MF2_ICEDAMAGE)
         {                       // Frozen player
             palette = STARTICEPAL;
@@ -1345,7 +1355,8 @@ void SB_SmoothPaletteFlash (boolean forceChange)
         palette = 0;
     }
 
-    if (palette != SB_palette || CPlayer->poisoncount || CPlayer->damagecount || CPlayer->bonuscount)
+    if (palette != SB_palette || CPlayer->poisoncount || CPlayer->damagecount || CPlayer->bonuscount
+    ||  CPlayer->graycount || CPlayer->orngcount)
     {
         SB_palette = palette;
         I_SetPalette(palette);

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -121,6 +121,7 @@ static SDL_Color palette[256];
 static boolean palette_to_set;
 // [JN] Smooth palette.
 int    red_pane_alpha, yel_pane_alpha, grn_pane_alpha;
+int    gray_pane_alpha, orng_pane_alpha;
 
 // display has been set up?
 
@@ -1171,7 +1172,14 @@ void I_SetPalette (int palette)
 	    break;
 	case 22:  // STARTHOLYPAL
 	    curpane = graypane;
+	    if (vis_smooth_palette)
+	    {
+	    pane_alpha = gray_pane_alpha;
+	    }
+	    else
+	    {
 	    pane_alpha = 0x7f; // 127 (50%)
+	    }
 	    break;
 	case 23:
 	    curpane = graypane;
@@ -1183,7 +1191,14 @@ void I_SetPalette (int palette)
 	    break;
 	case 25:  // STARTSCOURGEPAL
 	    curpane = orngpane;
+	    if (vis_smooth_palette)
+	    {
+	    pane_alpha = orng_pane_alpha;
+	    }
+	    else
+	    {
 	    pane_alpha = 0x7f; // 127 (50%)
+	    }
 	    break;
 	case 26:
 	    curpane = orngpane;

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -151,6 +151,7 @@ extern int demowarp;
 
 // [JN] Smooth palette.
 extern int red_pane_alpha, yel_pane_alpha, grn_pane_alpha;
+extern int gray_pane_alpha, orng_pane_alpha;
 
 // [AM] Fractional part of the current tic, in the half-open
 //      range of [0.0, 1.0).  Used for interpolation.


### PR DESCRIPTION
For Smooth Palette Fading feature. Ideally to save `graycount` and `orngcount` in the save game, but this will break compatibility with current save files. 