### PR TITLE
Fix typo in d_iwad comment

### DIFF
--- a/src/d_iwad.c
+++ b/src/d_iwad.c
@@ -114,7 +114,7 @@ typedef struct
 //
 // With some munging we can find where Doom was installed.
 
-// [AlexMax] From the persepctive of a 64-bit executable, 32-bit registry
+// [AlexMax] From the perspective of a 64-bit executable, 32-bit registry
 // keys are located in a different spot.
 #if _WIN64
 #define SOFTWARE_KEY "Software\\Wow6432Node"


### PR DESCRIPTION
## Summary
- correct spelling of `perspective` in `src/d_iwad.c`

## Testing
- `cmake -S . -B build` *(fails: SDL2_mixer and others not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840854f479c832f91e28499f77754f4