### PR TITLE
Textscreen: fix memory leak in Windows directory selection (Codex check)

### DIFF
--- a/textscreen/txt_fileselect.c
+++ b/textscreen/txt_fileselect.c
@@ -167,6 +167,7 @@ char *TXT_SelectFile(const char *window_title, const char **extensions)
 
 #include <windows.h>
 #include <shlobj.h>
+#include <objbase.h>
 
 static BOOL (*MyGetOpenFileName)(LPOPENFILENAME) = NULL;
 static LPITEMIDLIST (*MySHBrowseForFolder)(LPBROWSEINFO) = NULL;
@@ -284,7 +285,8 @@ static char *SelectDirectory(char *window_title)
             result = strdup(selected);
         }
 
-        // TODO: Free pidl
+        // Free memory allocated by SHBrowseForFolder
+        CoTaskMemFree(pidl);
     }
 
     return result;


### PR DESCRIPTION
## Summary
- free the PIDL returned by `SHBrowseForFolder`
- include `objbase.h` for `CoTaskMemFree`

## Testing
- `cmake ..` *(fails: SDL2_mixer::SDL2_mixer-static missing)*

------
https://chatgpt.com/codex/tasks/task_e_683fe1c2ca70832fad3fce3d513323ef