### PR TITLE
Heretic, Hexen: fix buffer overflow when playing sounds in some cases

### DIFF
--- a/src/heretic/s_sound.c
+++ b/src/heretic/s_sound.c
@@ -238,7 +238,7 @@ void S_StartSound(void *_origin, int sound_id)
     }
     for (i = 0; i < snd_channels; i++)
     {
-        if (origin->player)
+        if (origin != listener && origin->player)
         {
             i = snd_channels;
             break;              // let the player have more than one sound.

--- a/src/hexen/s_sound.c
+++ b/src/hexen/s_sound.c
@@ -251,6 +251,7 @@ void S_StartSound(mobj_t * origin, int sound_id)
     S_StartSoundAtVolume(origin, sound_id, 127);
 }
 
+
 static mobj_t *GetSoundListener(void)
 {
     static degenmobj_t dummy_listener;
@@ -351,7 +352,7 @@ void S_StartSoundAtVolume(mobj_t * origin, int sound_id, int volume)
     #endif
     for (i = 0; i < snd_channels; i++)
     {
-        if (origin->player)
+        if (origin != listener && origin->player)
         {
             i = snd_channels;
             break;              // let the player have more than one sound.


### PR DESCRIPTION
Fix buffer overflow below in Heretic and Hexem when `S_StartSound` is called with NULL parameter and the static listener is used. Trivially happens when no level is started and pressing ESC to display the menu


```
=================================================================
==283421==ERROR: AddressSanitizer: global-buffer-overflow on address 0x000000952b20 at pc 0x00000057193f bp 0x7ffc08032960 sp 0x7ffc08032958
READ of size 8 at 0x000000952b20 thread T0
    #0 0x00000057193e in S_StartSoundAtVolume /home/bobbie/git_projects/international-doom/src/hexen/s_sound.c:354
    #1 0x00000057145e in S_StartSound /home/bobbie/git_projects/international-doom/src/hexen/s_sound.c:251
    #2 0x0000004aa97c in MN_ActivateMenu /home/bobbie/git_projects/international-doom/src/hexen/mn_menu.c:6673
    #3 0x0000004a9180 in MN_Responder /home/bobbie/git_projects/international-doom/src/hexen/mn_menu.c:6367
    #4 0x00000047c8e1 in H2_ProcessEvents /home/bobbie/git_projects/international-doom/src/hexen/h2_main.c:944
    #5 0x000000416c9a in BuildNewTic /home/bobbie/git_projects/international-doom/src/d_loop.c:156
    #6 0x0000004170b5 in NetUpdate /home/bobbie/git_projects/international-doom/src/d_loop.c:250
    #7 0x000000418298 in TryRunTics /home/bobbie/git_projects/international-doom/src/d_loop.c:781
    #8 0x00000047c600 in H2_GameLoop /home/bobbie/git_projects/international-doom/src/hexen/h2_main.c:896
    #9 0x00000047b7b6 in D_DoomMain /home/bobbie/git_projects/international-doom/src/hexen/h2_main.c:598
    #10 0x000000407324 in main /home/bobbie/git_projects/international-doom/src/i_main.c:99
    #11 0x7fd84b62b37a in __libc_start_call_main (/lib64/libc.so.6+0x2b37a) (BuildId: 5f5a89c70625d4fc059c9e954c047f21fa5104d7)
    #12 0x7fd84b62b44a in __libc_start_main_impl (/lib64/libc.so.6+0x2b44a) (BuildId: 5f5a89c70625d4fc059c9e954c047f21fa5104d7)
    #13 0x000000407134 in _start ../sysdeps/x86_64/start.S:115

0x000000952b20 is located 28 bytes after global variable 'DebugSound' defined in '/home/bobbie/git_projects/international-doom/src/hexen/sb_bar.c:70:9' (0x000000952b00) of size 4
0x000000952b20 is located 32 bytes before global variable 'inventory' defined in '/home/bobbie/git_projects/international-doom/src/hexen/sb_bar.c:71:9' (0x000000952b40) of size 4
SUMMARY: AddressSanitizer: global-buffer-overflow /home/bobbie/git_projects/international-doom/src/hexen/s_sound.c:354 in S_StartSoundAtVolume
Shadow bytes around the buggy address:
  0x000000952880: 00 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9
  0x000000952900: 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9
  0x000000952980: 04 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9
  0x000000952a00: 04 f9 f9 f9 f9 f9 f9 f9 00 00 00 00 00 f9 f9 f9
  0x000000952a80: f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9 00 00 00 00
=>0x000000952b00: 04 f9 f9 f9[f9]f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9
  0x000000952b80: 04 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9
  0x000000952c00: 04 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9
  0x000000952c80: 04 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9
  0x000000952d00: 00 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9
  0x000000952d80: 04 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
```