### PR TITLE
Reimplement fuzz effect using palette indices with ARGB lookup

### DIFF
--- a/src/doom/r_local.h
+++ b/src/doom/r_local.h
@@ -445,6 +445,11 @@ extern fixed_t *spritetopoffset;
 
 extern lighttable_t *colormaps;
 
+extern byte     *colormaps_idx;
+extern uint32_t *argb2pal_keys;
+extern byte     *argb2pal_vals;
+extern int       argb2pal_mask;
+
 extern int viewwidth;
 extern int scaledviewwidth;
 extern int viewheight;


### PR DESCRIPTION
This PR restores the vanilla fuzz effect logic in the truecolor renderer. In vanilla Doom, fuzz columns are rendered by remapping framebuffer indices through `COLORMAP[6][]`. Since the truecolor renderer stores **ARGB** values instead of palette indices, we lost the direct path.

To replicate the authentic behavior:

* A raw copy of COLORMAP indices is kept (`colormaps_idx`).
* A reverse ARGB → palette index map is built at initialization, using a simple linear-probing hash with Knuth multiplicative hashing for distribution.
* During fuzz rendering, the ARGB source pixel is first resolved back to its palette index, then remapped via `COLORMAP[6][]`, and finally converted back to ARGB through `pal_color[]`.

This round-trip (index → ARGB buffer → index → palette) ensures the fuzz effect matches vanilla visuals, while remaining efficient enough for runtime use.