### PR TITLE
Hexen: support for kex iwad weapon pieces & lifegems

### DIFF
--- a/src/hexen/sb_bar.c
+++ b/src/hexen/sb_bar.c
@@ -429,30 +429,57 @@ void SB_Init(void)
 void SB_SetClassData(void)
 {
     int class;
+    char namebuf[9];
 
     class = PlayerClass[displayplayer]; // original player class (not pig)
     PatchWEAPONSLOT = W_CacheLumpNum(W_GetNumForName("wpslot0")
                                      + class, PU_STATIC);
     PatchWEAPONFULL = W_CacheLumpNum(W_GetNumForName("wpfull0")
                                      + class, PU_STATIC);
-    PatchPIECE1 = W_CacheLumpNum(W_GetNumForName("wpiecef1")
-                                 + class, PU_STATIC);
-    PatchPIECE2 = W_CacheLumpNum(W_GetNumForName("wpiecef2")
-                                 + class, PU_STATIC);
-    PatchPIECE3 = W_CacheLumpNum(W_GetNumForName("wpiecef3")
-                                 + class, PU_STATIC);
-    PatchCHAIN = W_CacheLumpNum(W_GetNumForName("chain") + class, PU_STATIC);
-    if (!netgame)
-    {                           // single player game uses red life gem (the second gem)
-        PatchLIFEGEM = W_CacheLumpNum(W_GetNumForName("lifegem")
-                                      + maxplayers * class + 1, PU_STATIC);
-    }
-    else
+    // support for kex and original iwad weapon pieces & lifegem lump numbers
+    // single player game uses red life gem (the second gem)
+    switch (class)
     {
-        PatchLIFEGEM = W_CacheLumpNum(W_GetNumForName("lifegem")
-                                      + maxplayers * class + displayplayer,
-                                      PU_STATIC);
+        case PCLASS_CLERIC:
+            PatchPIECE1 = W_CacheLumpNum(W_GetNumForName("wpiecec1"),
+                                 PU_STATIC);
+            PatchPIECE2 = W_CacheLumpNum(W_GetNumForName("wpiecec2"),
+                                 PU_STATIC);
+            PatchPIECE3 = W_CacheLumpNum(W_GetNumForName("wpiecec3"),
+                                 PU_STATIC);
+            M_snprintf(namebuf, sizeof(namebuf), "lifegmc%d", (netgame ? consoleplayer + 1 : 2));
+            PatchLIFEGEM = W_CacheLumpNum(W_GetNumForName(namebuf), PU_STATIC);
+            break;
+        case PCLASS_MAGE:
+            PatchPIECE1 = W_CacheLumpNum(W_GetNumForName("wpiecem1"),
+                                 PU_STATIC);
+            PatchPIECE2 = W_CacheLumpNum(W_GetNumForName("wpiecem2"),
+                                 PU_STATIC);
+            PatchPIECE3 = W_CacheLumpNum(W_GetNumForName("wpiecem3"),
+                                 PU_STATIC);
+            M_snprintf(namebuf, sizeof(namebuf), "lifegmm%d", (netgame ? consoleplayer + 1 : 2));
+            PatchLIFEGEM = W_CacheLumpNum(W_GetNumForName(namebuf), PU_STATIC);
+            break;
+        default:
+            // fighter
+            PatchPIECE1 = W_CacheLumpNum(W_GetNumForName("wpiecef1"),
+                                 PU_STATIC);
+            PatchPIECE2 = W_CacheLumpNum(W_GetNumForName("wpiecef2"),
+                                 PU_STATIC);
+            PatchPIECE3 = W_CacheLumpNum(W_GetNumForName("wpiecef3"),
+                                 PU_STATIC);
+            if (netgame && consoleplayer == 0)
+            {
+                PatchLIFEGEM = W_CacheLumpNum(W_GetNumForName("lifegem"),
+                                 PU_STATIC);       
+            }
+            else
+            {
+                M_snprintf(namebuf, sizeof(namebuf), "lifegmf%d", (netgame ? consoleplayer + 1 : 2));
+                PatchLIFEGEM = W_CacheLumpNum(W_GetNumForName(namebuf), PU_STATIC);               
+            }
     }
+    PatchCHAIN = W_CacheLumpNum(W_GetNumForName("chain") + class, PU_STATIC);
     SB_state = -1;
 }
 


### PR DESCRIPTION
Related Issue:
None

**Changes Summary**
For some reason, the kex hexen iwad changed lumpnum sequences when it comes to weapon pieces / lifegems.
With this change, both .wads shall be respected by explicitly mapping the pieces / lifegems per class. 

<img width="328" height="258" alt="grafik" src="https://github.com/user-attachments/assets/e7538454-7c74-4e35-ac2e-259b8fd26061" />
<img width="332" height="257" alt="grafik" src="https://github.com/user-attachments/assets/890632a2-e974-434c-8609-0031fa63ffd3" />
<img width="337" height="557" alt="grafik" src="https://github.com/user-attachments/assets/ab626448-4d66-496e-9ac7-472dfa28a311" />
<img width="345" height="555" alt="grafik" src="https://github.com/user-attachments/assets/4d47c033-f52d-483a-a81d-61ba1c6d8619" />

I see there is a class "random" in International Hexen, I tested it and it still seems to work correctly. It appears that only the three main classes are in the PlayerClass array.
