### PR TITLE
Fix app icon missing on GNOME

### DIFF
--- a/data/doom.desktop
+++ b/data/doom.desktop
@@ -6,3 +6,4 @@ Icon=inter-doom
 TryExec=inter-doom
 Categories=Game;
 MimeType=application/x-doom-wad;
+StartupWMClass=inter-doom

--- a/data/heretic.desktop
+++ b/data/heretic.desktop
@@ -6,3 +6,4 @@ Icon=inter-heretic
 TryExec=inter-heretic
 Categories=Game;
 MimeType=application/x-doom-wad;
+StartupWMClass=inter-heretic

--- a/data/hexen.desktop
+++ b/data/hexen.desktop
@@ -6,3 +6,4 @@ Icon=inter-hexen
 TryExec=inter-hexen
 Categories=Game;
 MimeType=application/x-doom-wad;
+StartupWMClass=inter-hexen


### PR DESCRIPTION
To properly associate .desktop files with a running instance of an application, GNOME requires either that the `StartupWMClass` key be in the .desktop file, matching the Wayland app_id or the X11 WM_CLASS, or that the filename (minus the ".desktop") match the app_id/WM_CLASS. For AppImages, relying on just the filename can have some issues, as AppImage managment tools like GearLever may rename them. This PR adds `StartupWMClass` keys to the desktop files, which fixes this.

Before:
<img width="153" height="225" alt="image" src="https://github.com/user-attachments/assets/9140a521-62f1-44cd-aeef-baf8dfae0e7c" />

After:
<img width="153" height="225" alt="image" src="https://github.com/user-attachments/assets/8d5e6d00-dc84-4151-9ee4-ffaaf90020b7" />