### PR TITLE
Fix view jolting up/down too much when running across tiny height variations

### DIFF
--- a/src/doom/p_user.c
+++ b/src/doom/p_user.c
@@ -43,6 +43,8 @@
 #define MAXBOB	0x100000	
 
 boolean		onground;
+int offgroundtics; // how many tics player has been in air
+#define AIRBOBFADETICS 4 // num tics to scale bobbing to 0 in midair
 
 // [JN] Player's breathing imitation.
 #define BREATHING_STEP 32
@@ -106,9 +108,11 @@ static void P_CalcHeight (player_t *const player)
         player->r_bob = player->bob;
     }
 
+    offgroundtics = onground ? 0 : offgroundtics + 1;
+
     // [JN] CRL - keep update viewz while no momentum mode
     // to prevent camera dive into the floor after stepping down any heights.
-    if (/*(player->cheats & CF_NOMOMENTUM) || */!onground)
+    if (/*(player->cheats & CF_NOMOMENTUM) || */!onground && (offgroundtics > AIRBOBFADETICS))
     {
 	player->viewz = player->mo->z + VIEWHEIGHT;
 
@@ -134,7 +138,7 @@ static void P_CalcHeight (player_t *const player)
     }
     
     // move viewheight
-    if (player->playerstate == PST_LIVE)
+    if (player->playerstate == PST_LIVE && onground)
     {
 	player->viewheight += player->deltaviewheight;
 
@@ -201,6 +205,10 @@ static void P_CalcHeight (player_t *const player)
 	    }
 	}
     }
+
+    if (!onground)
+        bob = bob * (AIRBOBFADETICS + 1 - offgroundtics) / AIRBOBFADETICS;
+
     player->viewz = player->mo->z + player->viewheight + bob;
 
     if (player->viewz > player->mo->ceilingz-4*FRACUNIT)


### PR DESCRIPTION
Same as https://github.com/fabiangreffrath/woof/pull/2815
(example videos before/after are there - especially look at second post)

When running over small sector height differences of 1 or 2 px, there is a nasty jolt in the camera viewbobbing.

This is because the player goes airborne for 1 tic, which snaps the viewbob amount to 0 immediately.
Then when landing the next tic the viewbob returns to its full magnitude, so the player sees a sudden big
spike in the camera viewheight.

This is alleviated in this PR by scaling the viewbob amount to 0 over several tics when going airborne
instead of snapping it to 0 immediately.

This change is only applied to Doom and not Heretic/Hexen, because Heretic/Hexen already continues
viewbobbing indefinitely when in midair, which means they do not get the view jolt.

The viewbob modification does not affect the weapon sprite, so demo compatibility should be unaffected.

Attached is a test wad for limitremoving doom since the example wads listed in the Woof PR are not compatible.

[jolttest.zip](https://github.com/user-attachments/files/31837823/jolttest.zip)

- Compare the regular stairs vs the ones with the silver slightly raised dividers
- Try running around the missing tiles zone
- Try running across all of the raised platforms